### PR TITLE
Repeat (looping)

### DIFF
--- a/js/objects/tests/test-if-then-with-preload.js
+++ b/js/objects/tests/test-if-then-with-preload.js
@@ -95,7 +95,7 @@ describe('Inline if-then tests', () => {
     it('Can deal with an equality comparison (true)', () => {
         let script = [
             'on click',
-            '\tif (2+2) = 4 then set "name" to "evaluated3"',
+            '\tif (2+2) == 4 then set "name" to "evaluated3"',
             'end click'
         ].join('\n');
         compileButtonScript(script);
@@ -111,7 +111,7 @@ describe('Inline if-then tests', () => {
     it('Can deal with an equality comparison (false)', () => {
         let script = [
             'on click',
-            '\tif (2+3) = 4 then set "name" to "evaluated4"',
+            '\tif (2+3) == 4 then set "name" to "evaluated4"',
             'end click'
         ].join('\n');
         compileButtonScript(script);
@@ -300,7 +300,7 @@ describe('Singleline If-Then tests', () => {
     it('Can deal with an equality comparison (true)', () => {
         let script = [
             'on click',
-            '\tif (2+2) = 4',
+            '\tif (2+2) == 4',
             'then set "name" to "evaluated3"',
             'end click'
         ].join('\n');
@@ -317,7 +317,7 @@ describe('Singleline If-Then tests', () => {
     it('Can deal with an equality comparison (false)', () => {
         let script = [
             'on click',
-            '\tif (2+3) = 4',
+            '\tif (2+3) == 4',
             'then set "name" to "evaluated4"',
             'end click'
         ].join('\n');

--- a/js/objects/tests/test-repeat-with-preload.js
+++ b/js/objects/tests/test-repeat-with-preload.js
@@ -153,7 +153,7 @@ describe("Repeat Looping Tests", () => {
     });
 
     describe("Misc example tests", () => {
-        it("Can exit repeat on if condition", () => {
+        it("Can exit repeat on if condition (until)", () => {
             let script = [
                 "on click",
                 "put 0 into Counter",
@@ -169,6 +169,133 @@ describe("Repeat Looping Tests", () => {
             let result = getLocalVar(buttonModel, 'Counter');
             assert.equal(result, 3);
         });
+
+        it("Can exit repeat on if condition (forNumTimes)", () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "repeat 5 times",
+                "if Counter = 4 then exit repeat",
+                "put (Counter + 1) into Counter",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let result = getLocalVar(buttonModel, 'Counter');
+            assert.equal(result, 4);
+        });
+
+        it("Can exit repeat on if condition (while)", () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "put 0 into timesItLooped",
+                "repeat while Counter < 6",
+                "put (Counter + 1) into Counter",
+                "if Counter > 3 then exit repeat",
+                "put (timesItLooped + 1) into timesItLooped",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let counter = getLocalVar(buttonModel, 'Counter');
+            let timesItLooped = getLocalVar(buttonModel, 'timesItLooped');
+            assert.equal(counter, 4);
+            assert.equal(timesItLooped, 3);
+        });
+
+        it("Can exit repeat on if condition (withStartFinish)", () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "repeat with realCount = 2 to 7",
+                "if Counter > 2 then exit repeat",
+                "put (Counter + 1) into Counter",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let counter = getLocalVar(buttonModel, 'Counter');
+            let finalIndex = getLocalVar(buttonModel, 'realCount');
+            assert.equal(counter, 3);
+            assert.equal(finalIndex, 5);
+        });
+
+        it("Can next repeat on if condition (until)", () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "put 0 into CounterMinusOne",
+                "repeat until Counter = 5",
+                "answer Counter",
+                "put (Counter + 1) into Counter",
+                "if Counter = 3 then next repeat",
+                "put (CounterMinusOne + 1) into CounterMinusOne",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let result = getLocalVar(buttonModel, 'Counter');
+            let backupResult = getLocalVar(buttonModel, 'CounterMinusOne');
+            assert.equal(result, 5);
+            assert.equal(backupResult, 4);
+        });
+
+        it("Can next repeat on if condition (forNumTimes)", () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "repeat for 10 times",
+                "if Counter > 3 then next repeat",
+                "put (Counter + 1) into Counter",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let result = getLocalVar(buttonModel, 'Counter');
+            assert.equal(result, 4);
+        });
+
+        it("Can next repeat on if condition (while)", () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "put 0 into timesItLooped",
+                "repeat while Counter < 6",
+                "put (Counter + 1) into Counter",
+                "if Counter = 3 then next repeat",
+                "put (timesItLooped + 1) into timesItLooped",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let counter = getLocalVar(buttonModel, 'Counter');
+            let timesItLooped = getLocalVar(buttonModel, 'timesItLooped');
+            assert.equal(counter, 6);
+            assert.equal(timesItLooped, 5);
+        });
+
+        it("Can next repeat on if condition (withStartFinish)" , () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "repeat with realCount = 2 to 7",
+                "if realCount = 4 then next repeat",
+                "put (Counter + 1) into Counter",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let counter = getLocalVar(buttonModel, "Counter");
+            assert.equal(counter, 4);
+        });        
     });
 });
 

--- a/js/objects/tests/test-repeat-with-preload.js
+++ b/js/objects/tests/test-repeat-with-preload.js
@@ -101,13 +101,54 @@ describe("Repeat Looping Tests", () => {
                 "\tend repeat",
                 "end click"
             ].join("\n");
-            console.log(script);
             compileButtonScript(script);
             sendButtonClick(script);
             let resultLimit = getLocalVar(buttonModel, "myLimit");
             let resultCount = getLocalVar(buttonModel, "myCount");
             assert.equal(resultLimit, 0);
             assert.equal(resultCount, 5);
+        });
+    });
+
+    describe("Repeat whileCondition tests", () => {
+        it("Can compile and loop while condition is true", () => {
+            let script = [
+                "on click",
+                "\tput 0 into myLimit",
+                "\tput 0 into myCount",
+                "\trepeat while myLimit < 6 ",
+                "\tput (myCount + 1) into myCount",
+                "\tput (myLimit + 1) into myLimit",
+                "\tend repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick(script);
+            let resultLimit = getLocalVar(buttonModel, "myLimit");
+            let resultCount = getLocalVar(buttonModel, "myCount");
+            assert.equal(resultLimit, 6);
+            assert.equal(resultCount, 6);
+        });
+    });
+
+    describe("Repeat withStartFinish tests", () => {
+        it("Can compile and run when range is valid", () => {
+            let script = [
+                "on click",
+                "put 0 into myTotal",
+                "put 0 into myCount",
+                "repeat with realCount = 1 to 3",
+                "put (realCount + myTotal) into myTotal",
+                "put (myCount + 1) into myCount",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let resultTotal = getLocalVar(buttonModel, 'myTotal');
+            let resultCount = getLocalVar(buttonModel, "myCount");
+            assert.equal(resultCount, 3);
+            assert.equal(resultTotal, 6);
         });
     });
 });

--- a/js/objects/tests/test-repeat-with-preload.js
+++ b/js/objects/tests/test-repeat-with-preload.js
@@ -151,6 +151,25 @@ describe("Repeat Looping Tests", () => {
             assert.equal(resultTotal, 6);
         });
     });
+
+    describe("Misc example tests", () => {
+        it("Can exit repeat on if condition", () => {
+            let script = [
+                "on click",
+                "put 0 into Counter",
+                "repeat until Counter = 5",
+                "answer Counter",
+                "put (Counter + 1) into Counter",
+                "if Counter >= 3 then exit repeat",
+                "end repeat",
+                "end click"
+            ].join("\n");
+            compileButtonScript(script);
+            sendButtonClick();
+            let result = getLocalVar(buttonModel, 'Counter');
+            assert.equal(result, 3);
+        });
+    });
 });
 
 

--- a/js/objects/tests/test-repeat-with-preload.js
+++ b/js/objects/tests/test-repeat-with-preload.js
@@ -157,7 +157,7 @@ describe("Repeat Looping Tests", () => {
             let script = [
                 "on click",
                 "put 0 into Counter",
-                "repeat until Counter = 5",
+                "repeat until Counter == 5",
                 "answer Counter",
                 "put (Counter + 1) into Counter",
                 "if Counter >= 3 then exit repeat",
@@ -175,7 +175,7 @@ describe("Repeat Looping Tests", () => {
                 "on click",
                 "put 0 into Counter",
                 "repeat 5 times",
-                "if Counter = 4 then exit repeat",
+                "if Counter == 4 then exit repeat",
                 "put (Counter + 1) into Counter",
                 "end repeat",
                 "end click"
@@ -229,10 +229,10 @@ describe("Repeat Looping Tests", () => {
                 "on click",
                 "put 0 into Counter",
                 "put 0 into CounterMinusOne",
-                "repeat until Counter = 5",
+                "repeat until Counter == 5",
                 "answer Counter",
                 "put (Counter + 1) into Counter",
-                "if Counter = 3 then next repeat",
+                "if Counter == 3 then next repeat",
                 "put (CounterMinusOne + 1) into CounterMinusOne",
                 "end repeat",
                 "end click"
@@ -268,7 +268,7 @@ describe("Repeat Looping Tests", () => {
                 "put 0 into timesItLooped",
                 "repeat while Counter < 6",
                 "put (Counter + 1) into Counter",
-                "if Counter = 3 then next repeat",
+                "if Counter == 3 then next repeat",
                 "put (timesItLooped + 1) into timesItLooped",
                 "end repeat",
                 "end click"
@@ -286,7 +286,7 @@ describe("Repeat Looping Tests", () => {
                 "on click",
                 "put 0 into Counter",
                 "repeat with realCount = 2 to 7",
-                "if realCount = 4 then next repeat",
+                "if realCount == 4 then next repeat",
                 "put (Counter + 1) into Counter",
                 "end repeat",
                 "end click"

--- a/js/objects/tests/test-repeat-with-preload.js
+++ b/js/objects/tests/test-repeat-with-preload.js
@@ -59,7 +59,6 @@ describe("Repeat Looping Tests", () => {
     });
 
     describe("Repeat forNumTimes tests", () => {
-        describe("Basic integer", () => {
             it("Can compile a basic script and loop correct num times", () => {
                 let script = [
                     "on click",
@@ -89,8 +88,30 @@ describe("Repeat Looping Tests", () => {
                 let result = getLocalVar(buttonModel, "myNum");
                 assert.equal(result, 3);
             });
+    });
+    describe("Repeat untilCondition tests", () => {
+        it("Can compile and loop until condition is met", () => {
+            let script = [
+                "on click",
+                "\tput 5 into myLimit",
+                "\tput 0 into myCount",
+                "\trepeat until myLimit <= 0",
+                "\tput (myCount + 1) into myCount",
+                "\tput (myLimit - 1) into myLimit",
+                "\tend repeat",
+                "end click"
+            ].join("\n");
+            console.log(script);
+            compileButtonScript(script);
+            sendButtonClick(script);
+            let resultLimit = getLocalVar(buttonModel, "myLimit");
+            let resultCount = getLocalVar(buttonModel, "myCount");
+            assert.equal(resultLimit, 0);
+            assert.equal(resultCount, 5);
         });
     });
 });
+
+
 
 

--- a/js/objects/tests/test-repeat-with-preload.js
+++ b/js/objects/tests/test-repeat-with-preload.js
@@ -1,0 +1,96 @@
+import chai from 'chai';
+const assert = chai.assert;
+const expect = chai.expect;
+
+let currentCardModel;
+let buttonModel;
+
+function compileButtonScript(aScript){
+    let msg = {
+        type: 'compile',
+        codeString: aScript,
+        targetId: buttonModel.id
+    };
+    window.System.compile(msg);
+};
+
+function sendButtonClick(){
+    let clickMessage = {
+        type: 'command',
+        commandName: 'click',
+        args: []
+    };
+    buttonModel.sendMessage(clickMessage, buttonModel);
+};
+
+function getLocalVar(obj, varName){
+    return obj._executionContext.getLocal(varName);
+};
+
+describe("Repeat Looping Tests", () => {
+    describe("Model Setup", () => {
+        it('Can find the current card model', () => {
+            let currentCardView = document.querySelector('.current-stack > .current-card');
+            currentCardModel = currentCardView.model;
+            assert.exists(currentCardModel);
+        });
+        it('Can add a button to current card model without error', () => {
+            let addButton = function(){
+                let msg = {
+                    type: 'command',
+                    commandName: 'newModel',
+                    args: [
+                        'button',
+                        currentCardModel.id,
+                        'card'
+                    ]
+                };
+                currentCardModel.sendMessage(msg, currentCardModel);
+            };
+            expect(addButton).to.not.throw(Error);
+        });
+        it('Can find newly created button model', () => {
+            let button = currentCardModel.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            buttonModel = button;
+            assert.exists(buttonModel);
+        });
+    });
+
+    describe("Repeat forNumTimes tests", () => {
+        describe("Basic integer", () => {
+            it("Can compile a basic script and loop correct num times", () => {
+                let script = [
+                    "on click",
+                    "put 0 into myNum",
+                    "repeat for 5 times",
+                    "put (myNum + 1) into myNum",
+                    "end repeat",
+                    "end click"
+                ].join("\n");
+                compileButtonScript(script);
+                sendButtonClick(script);
+                let result = getLocalVar(buttonModel, "myNum");
+                assert.equal(result, 5);
+            });
+            it("Can compile a script and loop num times based on variable", () => {
+                let script = [
+                    "on click",
+                    "put 0 into myNum",
+                    "put 3 into myCount",
+                    "repeat for myCount times",
+                    "put (myNum + 1) into myNum",
+                    "end repeat",
+                    "end click"
+                ].join("\n");
+                compileButtonScript(script);
+                sendButtonClick(script);
+                let result = getLocalVar(buttonModel, "myNum");
+                assert.equal(result, 3);
+            });
+        });
+    });
+});
+
+

--- a/js/objects/tests/test-variable-scripts-with-preload.js
+++ b/js/objects/tests/test-variable-scripts-with-preload.js
@@ -66,6 +66,26 @@ describe('Basic Set Local Variable', () => {
         let variableValue = buttonModel._executionContext.getLocal('myVariable');
         assert.equal(variableValue, "hello");
     });
+
+    it('Throws an error if attempting to read an undefined variable', () => {
+        let testScript = [
+            "on click",
+            "put (notYetDefined + 7) into myNewVariable",
+            "end click"
+        ].join("\n");
+        let sendFunction = function(){
+            let msg = {
+                type: 'compile',
+                codeString: script,
+                targetId: buttonModel.id
+            };
+            window.System.compile(msg);
+        };
+        expect(sendFunction).to.not.throw(Error);
+        let buttonView = document.querySelector(`[part-id="${buttonModel.id}"]`);
+        assert.exists(buttonView);
+        expect(buttonView.click).to.throw();
+    });
 });
 
 describe('Can set property based on local variable', () => {

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -320,7 +320,7 @@ const createInterpreterSemantics = (partContext, systemContext) => {
                 partContext._executionContext.setLocal('it', commandResult);
                 return message;
             } else {
-                return null;
+                return statement.sourceString;
             }
         },
 
@@ -386,10 +386,10 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return first <= second;
         },
 
-        IfThenInline: function(ifLiteral, conditional, thenLiteral, command, optionalComment){
+        IfThenInline: function(ifLiteral, conditional, thenLiteral, statement, optionalComment){
             let shouldEvaluate = conditional.interpret();
             if(shouldEvaluate){
-                return command.interpret();
+                return statement.interpret();
             } else {
                 return null;
             }
@@ -417,12 +417,12 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return conditional.interpret();
         },
 
-        ThenLine: function(thenLiteral, command, optionalComment){
-            return command.interpret();
+        ThenLine: function(thenLiteral, statement, optionalComment){
+            return statement.interpret();
         },
 
-        ElseLine: function(elseLiteral, command, optionalComment){
-            return command.interpret();
+        ElseLine: function(elseLiteral, statement, optionalComment){
+            return statement.interpret();
         },
 
         KindConditional: function(expr1, comparatorLiteral, expr2){
@@ -467,16 +467,12 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             };
         },
 
-        RepeatAdjust_exit: function(_, lineTerm, optComment){
-            return {
-                type: 'repeatAdjustExit'
-            };
+        RepeatAdjust_exit: function(_){
+            return null;
         },
 
-        RepeatAdjust_next: function(_, lineTerm, optComment){
-            return {
-                type: 'repeatAdjustNext'
-            };
+        RepeatAdjust_next: function(_){
+            return null;
         },
 
         RepeatBlock: function(repeatControl, lineTerm, statementLineOrRepAdjustPlus, endLiteral){
@@ -513,10 +509,11 @@ const createInterpreterSemantics = (partContext, systemContext) => {
                     let shouldBreak = false;
                     for(let i = 0; i < statementLines.length; i++){
                         let currentStatement = statementLines[i];
-                        if(currentStatement.type == 'repeatAdjustExit'){
+                        console.log(currentStatement.sourceString);
+                        if(currentStatement == 'exit repeat'){
                             shouldBreak = true;
                             break; // break out of this inner loop
-                        } else if(currentStatement.type == 'repeatAdjustNext'){
+                        } else if(currentStatement == 'next repeat'){
                             break; // break out of this inner loop
                         } else {
                             currentStatement.interpret();

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -606,7 +606,14 @@ const createInterpreterSemantics = (partContext, systemContext) => {
         variableName: function(letterPlus, optionalDigits){
             // Lookup the variable in the part's
             // current execution context
-            return partContext._executionContext.get(this.sourceString);
+            // If the variable is not a key on the object,
+            // we throw an error: this means the variable has not yet
+            // been defined but is being looked up.
+            let value = partContext._executionContext.get(this.sourceString);
+            if(value == undefined){
+                throw new Error(`Variable ${this.sourceString} has not been defined`);
+            }
+            return value;
         },
 
         _terminal(){

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -75,6 +75,7 @@
         Expression
                = Expression "+" Expression --addExpr
                | Expression "*" Expression --timesExpr
+			   | Expression "-" Expression --minusExpr
                | Factor
 
 

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -52,6 +52,7 @@
                 | ~"end" IfThenInline comment?
                 | ~"end" IfThenSingleline comment?
                 | ~"end" IfThenMultiline comment?
+                | ~"end" RepeatBlock comment?
 
         // The HT manual describes a Factor as being:
         // "a single element of value in an expression".
@@ -142,8 +143,12 @@
 			| "repeat" "with" variableName "=" (integerLiteral|variableName) "to" (integerLiteral|variableName) --withStartFinish
 			| "repeat" --forever
 
+		RepeatAdjust
+			= "exit repeat" lineTerminator comment? --exit
+			| "next repeat" lineTerminator comment? --next
+
 		RepeatBlock
-			= RepeatControlForm lineTerminator StatementLine+ "end repeat"
+			= RepeatControlForm lineTerminator (StatementLine|RepeatAdjust)+ "end repeat"
                 
 
         // Expression lists are those that are passed
@@ -170,7 +175,7 @@
 		| "delete" "this"? systemObject objectId? --deleteModel
 		| "add" systemObject stringLiteral? "to"? ("this" | "current")? systemObject? objectId? --addModel
 		| "set" stringLiteral "to" (stringLiteral | variableName) InClause? --setProperty
-		| "put" anyLiteral "into" "global"? variableName --putVariable
+		| "put" Factor "into" "global"? variableName --putVariable
 		| "ask" anyLiteral --ask
 		| "respond to" anyLiteral InClause? --eventRespond
 		| "ignore" anyLiteral InClause? --eventIgnore

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -45,7 +45,7 @@
 	StatementLine (a statement line)
                 = comment lineTerminator+
 		| Statement lineTerminator+
-
+	
 	// Note we explicitly exclude keywords, i.e. control
 	Statement (a statement)
 		= ~"end" Command comment?
@@ -134,7 +134,16 @@
                = IfLine lineTerminator MultiThen EndIfLine --withoutElse
                | IfLine lineTerminator MultiThen MultiElse --withElse
 
+		// Looping (repeat)
+		RepeatControlForm
+			= "repeat" "for"? (integerLiteral|variableName) "times" --forNumTimes
+			| "repeat" "until" Conditional --untilCondition
+			| "repeat" "while" Conditional --whileCondition
+			| "repeat" "with" variableName "=" (integerLiteral|variableName) "to" (integerLiteral|variableName) --withStartFinish
+			| "repeat" --forever
 
+		RepeatBlock
+			= RepeatControlForm lineTerminator StatementLine+ "end repeat"
                 
 
         // Expression lists are those that are passed

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -85,7 +85,7 @@
         // are compared using an operator, and the result
         // is expected to be a boolean value
         EqualityConditional
-               = Expression "=" Expression
+               = Expression "==" Expression
                | Expression "is" Expression
         
         NonEqualityConditional

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -48,11 +48,13 @@
 	
 	// Note we explicitly exclude keywords, i.e. control
 	Statement (a statement)
-		= ~"end" Command comment?
-                | ~"end" IfThenInline comment?
+                = ~"end" IfThenInline comment?
                 | ~"end" IfThenSingleline comment?
                 | ~"end" IfThenMultiline comment?
                 | ~"end" RepeatBlock comment?
+                | ~"end" RepeatAdjust comment?
+                | ~"end" Command comment?
+
 
         // The HT manual describes a Factor as being:
         // "a single element of value in an expression".
@@ -110,15 +112,15 @@
                | Factor // This gives us variableName and some other literals should we need them
                
         IfThenInline
-               = "if" Conditional "then" Command comment?
+               = "if" Conditional "then" Statement comment?
         IfLine
                = "if" Conditional comment?
         
         ElseLine
-               = "else" Command comment?
+               = "else" Statement comment?
                
         ThenLine
-               = "then" Command comment?
+               = "then" Statement comment?
 
         EndIfLine
               = "end if" comment?
@@ -145,8 +147,8 @@
 			| "repeat" --forever
 
 		RepeatAdjust
-			= "exit repeat" lineTerminator comment? --exit
-			| "next repeat" lineTerminator comment? --next
+			= "exit repeat" --exit
+			| "next repeat" --next
 
 		RepeatBlock
 			= RepeatControlForm lineTerminator (StatementLine|RepeatAdjust)+ "end repeat"

--- a/js/ohm/tests/test-conditional-grammar.js
+++ b/js/ohm/tests/test-conditional-grammar.js
@@ -28,17 +28,17 @@ const semanticMatchTest = (str, semanticType) => {
 describe("Basic Literal Conditional Tests", () => {
     describe("Equality via = sign", () => {
         it("Can deal with Integer literals", () => {
-            let str = `2 = 4`;
+            let str = `2 == 4`;
             semanticMatchTest(str, "EqualityConditional");
             semanticMatchTest(str, "Conditional");
         });
         it("Can deal with Float literals", () => {
-            let str = `0.1409 = 22.4`;
+            let str = `0.1409 == 22.4`;
             semanticMatchTest(str, "EqualityConditional");
             semanticMatchTest(str, "Conditional");
         });
         it("Can deal with String literals", () => {
-            let str = `"this is the first string" = "this is the second string"`;
+            let str = `"this is the first string" == "this is the second string"`;
             semanticMatchTest(str, "EqualityConditional");
             semanticMatchTest(str, "Conditional");
         });

--- a/js/ohm/tests/test-if-then-else-grammar.js
+++ b/js/ohm/tests/test-if-then-else-grammar.js
@@ -34,7 +34,7 @@ const semanticMatchTest = (str, semanticType) => {
 
 describe("Basic IfThenInline", () => {
     it("Can handle basic comparison", () => {
-        let str = `if 2 = 2 then go to next card`;
+        let str = `if 2 == 2 then go to next card`;
         semanticMatchTest(str, "IfThenInline");
     });
     it("Can handle comparison with variable", () => {
@@ -75,7 +75,7 @@ describe("Basic IfThenSingleline", () => {
     describe("Without 'else'", () => {
         it("Can handle basic comparison", () => {
             let str = [
-                'if 2 = 2',
+                'if 2 == 2',
                 'then go to next card'
             ].join('\n');
             semanticMatchTest(str, "IfThenSingleline");
@@ -140,7 +140,7 @@ describe("Basic IfThenSingleline", () => {
     describe("With 'else'", () => {
         it("Can handle basic comparison", () => {
             let str = [
-                'if 2 = 2',
+                'if 2 == 2',
                 'then go to next card',
                 'else put 5 into myVariable'
             ].join("\n");
@@ -217,7 +217,7 @@ describe("Basic IfThenMultiline", () => {
     describe("Without else", () => {
         it('Can handle basic comparison', () => {
             let str = [
-                'if 2 = 2',
+                'if 2 == 2',
                 'then',
                 'doSomething',
                 'go to next card',
@@ -228,7 +228,7 @@ describe("Basic IfThenMultiline", () => {
         });
         it('Can handle comparison with a variable', () => {
             let str = [
-                'if 2 = myVariable',
+                'if 2 == myVariable',
                 'then',
                 'doSomething',
                 'go to next card',
@@ -318,7 +318,7 @@ describe("Basic IfThenMultiline", () => {
     describe('With else', () => {
         it('Can handle basic comparison', () => {
             let str = [
-                'if 2 = 2',
+                'if 2 == 2',
                 'then',
                 'doSomething',
                 'go to next card',

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -93,3 +93,51 @@ describe("RepeatControlForm tests", () => {
         });
     });
 });
+
+describe("RepeatBlock tests", () => {
+    it("forNumTimes", () => {
+        let str = [
+            "repeat for 5 times",
+            "doSomething",
+            "go to next card",
+            "end repeat"
+        ].join("\n");
+        semanticMatchTest(str, "RepeatBlock");
+    });
+    it('untilCondition', () => {
+        let str = [
+            "repeat until myVariable >= 20.5",
+            "doSomething myVariable",
+            "go to card myVariable",
+            "end repeat"
+        ].join("\n");
+        semanticMatchTest(str, "RepeatBlock");
+    });
+    it("whileCondition", () => {
+        let str = [
+            "repeat while myVariable >= 20.5",
+            "doSomething myVariable",
+            "go to card myVariable",
+            "end repeat"
+        ].join("\n");
+        semanticMatchTest(str, "RepeatBlock");
+    });
+    it("withStartFinish", () => {
+        let str = [
+            "repeat with myNum = 0 to 6",
+            "doSomething myVariable",
+            "go to card myVariable",
+            "end repeat"
+        ].join("\n");
+        semanticMatchTest(str, "RepeatBlock");
+    });
+    it("forever", () => {
+        let str = [
+            "repeat",
+            "doSomething myVariable",
+            "go to card myVariable",
+            "end repeat"
+        ].join("\n");
+        semanticMatchTest(str, "RepeatBlock");
+    });
+});

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -141,3 +141,18 @@ describe("RepeatBlock tests", () => {
         semanticMatchTest(str, "RepeatBlock");
     });
 });
+
+describe("Repeat full script tests", () => {
+    it("forNumTimes", () => {
+        let script = [
+            "on click",
+            "put 0 into myNum",
+            "repeat for 5 times",
+            "put (myNum + 1) into myNum",
+            "end repeat",
+            "end click"
+        ].join("\n");
+        semanticMatchTest(script, "MessageHandler");
+        semanticMatchTest(script, "Script");
+    });
+});

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -1,0 +1,95 @@
+/**
+ * Repeat Grammar Tests
+ * --------------------------------
+ * Tests the grammar of looping constructs
+ */
+ohm = require('ohm-js');
+// Instantiate the grammar.
+var fs = require('fs');
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+
+var chai = require('chai');
+var assert = chai.assert;
+
+const matchTest = (str) => {
+    const match = g.match(str);
+    assert.isTrue(match.succeeded());
+};
+const semanticMatchTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isTrue(typeMatch.succeeded());
+};
+
+const semanticMatchFailTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isFalse(typeMatch.succeeded());
+};
+
+describe("RepeatControlForm tests", () => {
+    describe("forNumTimes", () => {
+        it("Can do basic repeat of literal integer", () => {
+            let str = "repeat for 5 times";
+            semanticMatchTest(str, "RepeatControlForm_forNumTimes");
+        });
+        it("Can do basic repeat of variable (assume integer)", () => {
+            let str = "repeat for myCustomNum times";
+            semanticMatchTest(str, "RepeatControlForm_forNumTimes");
+        });
+        it("Fails when attempting to do a float literal", () => {
+            let str = "repeat for 0.5 times";
+            semanticMatchFailTest(str, "RepeatControlForm_forNumTimes");
+        });
+        it("Fails when attemting to use a string literal", () => {
+            let str = `repeat for "3" times`;
+            semanticMatchFailTest(str, "RepeatControlForm_forNumTimes");
+        });
+    });
+    describe("untilCondition", () => {
+        it("Can do a boolean literal", () => {
+            let str = `repeat until true`;
+            semanticMatchTest(str, "RepeatControlForm_untilCondition");
+        });
+        it("Can do a variable name as the condition", () => {
+            let str = `repeat until myVariable`;
+            semanticMatchTest(str, "RepeatControlForm_untilCondition");
+        });
+        it("Can use a conditional statement of literals", () => {
+            let str = `repeat until 2 > 3`;
+            semanticMatchTest(str, "RepeatControlForm_untilCondition");
+        });
+        it("Can use a conditional that has variable name(s)", () => {
+            let str = `repeat until myVariable is 5`;
+            semanticMatchTest(str, "RepeatControlForm_untilCondition");
+        });
+    });
+    describe("whileCondition", () => {
+       it("Can do a boolean literal", () => {
+            let str = `repeat while true`;
+            semanticMatchTest(str, "RepeatControlForm_whileCondition");
+        });
+        it("Can do a variable name as the condition", () => {
+            let str = `repeat while myVariable`;
+            semanticMatchTest(str, "RepeatControlForm_whileCondition");
+        });
+        it("Can use a conditional statement of literals", () => {
+            let str = `repeat while 2 > 3`;
+            semanticMatchTest(str, "RepeatControlForm_whileCondition");
+        });
+        it("Can use a conditional that has variable name(s)", () => {
+            let str = `repeat while myVariable is 5`;
+            semanticMatchTest(str, "RepeatControlForm_whileCondition");
+        }); 
+    });
+    describe("withStartFinish", () => {
+        it("Can use a basic variable name with literal integer range", () => {
+            let str = `repeat with myNum = 0 to 100`;
+            semanticMatchTest(str, "RepeatControlForm_withStartFinish");
+        });
+    });
+    describe("forever", () => {
+        it("Can understand the forever repeat", () => {
+            let str = `repeat `;
+            semanticMatchTest(str, "RepeatControlForm_forever");
+        });
+    });
+});

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -176,7 +176,7 @@ describe("Misc full script repeat tests", () => {
         let script = [
         "on click",
         "put 0 into Counter",
-        "repeat until Counter = 5",
+        "repeat until Counter == 5",
         "answer Counter",
         "put (Counter + 1) into Counter",
         "if Counter >= 3 then exit repeat",

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -170,3 +170,20 @@ describe("Repeat full script tests", () => {
         semanticMatchTest(script, "MessageHandler");
     });
 });
+
+describe("Misc full script repeat tests", () => {
+    it("Can parse an exit repeat in nested if block", () => {
+        let script = [
+        "on click",
+        "put 0 into Counter",
+        "repeat until Counter = 5",
+        "answer Counter",
+        "put (Counter + 1) into Counter",
+        "if Counter >= 3 then exit repeat",
+        "end repeat",
+        "end click"
+        ].join("\n");
+        semanticMatchTest(script, "Script");
+        semanticMatchTest(script, "MessageHandler");
+    });
+});

--- a/js/ohm/tests/test-repeat-grammar.js
+++ b/js/ohm/tests/test-repeat-grammar.js
@@ -106,7 +106,7 @@ describe("RepeatBlock tests", () => {
     });
     it('untilCondition', () => {
         let str = [
-            "repeat until myVariable >= 20.5",
+            "repeat until myVariable <= 20.5",
             "doSomething myVariable",
             "go to card myVariable",
             "end repeat"
@@ -154,5 +154,19 @@ describe("Repeat full script tests", () => {
         ].join("\n");
         semanticMatchTest(script, "MessageHandler");
         semanticMatchTest(script, "Script");
+    });
+    it("untilCondition", () => {
+        let script = [
+            "on click",
+            "\tput 5 into myLimit",
+            "\tput 0 into myCount",
+            "\trepeat until myLimit <= 0",
+            "\tput (myCount + 1) into myCount",
+            "\tput (myLimit - 1) into myLimit",
+            "\tend repeat",
+            "end click"
+        ].join("\n");
+        semanticMatchTest(script, "Script");
+        semanticMatchTest(script, "MessageHandler");
     });
 });


### PR DESCRIPTION
## What
This PR implements the basic looping constructs, called `repeat`. It is based almost entirely upon the HT specification.
  
## Implementation ##
### Repeat Blocks ###
Looping is conducted inside of what we call "repeat blocks." Each of these blocks begins with the keyword `repeat` (along with more specific forms), some lines of statements to execute each run of the loop, and the `end repeat` to finish the block. There are several types of repeat blocks one can use:
#### `repeat for` ####
This construct repeats a loop for some number of times.
```simpletalk
repeat for 5 times
    beep
end repeat
```
#### `repeat until` ####
This construct will repeat the loop until some condition evaluates to true:
```simpletalk
put 5 into myCounter
repeat until myCounter <= 0
    beep
    put (myCounter - 2) into myCounter
end repeat
```
#### `repeat while` ####
This construct is the opposite of the `until` variant, and will repeat the statements in the block as long as the conditional evluates to true
```simpletalk
put 0 into myVariable
repeat while myVariable < 5
    beep
    put (myVariable + 3) into myVariable
end repeat
```
#### `repeat with` ####
This construct specifies a range and puts the current index of that range into a named variable in the repeat line:
```simpletalk
repeat with myCounter = 4 to 12
    beep
    answer myCounter
end repeat
```
### Adjustment Statements ###
There are two kinds of "adjustment statements" one can make inside of a repeat block: `exit repeat`, which breaks the loop entirely, and `next repeat` which stops executing the current statement loop and skips to the next run of the loop.
  
## Tests ##
Included are [grammar tests](https://github.com/UnitedLexCorp/SimpleTalk/blob/eric-repeat/js/ohm/tests/test-repeat-grammar.js) and [integration/interpreter tests](https://github.com/UnitedLexCorp/SimpleTalk/blob/eric-repeat/js/objects/tests/test-repeat-with-preload.js). All are passing.