### PR TITLE
Button editor

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -93,8 +93,6 @@ st-world > .current-stack > st-background {
 }
 
 
-
-
 /* =Card Styles
  *----------------------------------------------------*/
 st-card {
@@ -216,6 +214,19 @@ st-field {
     height: 300px;
 }
 
+/* =Editor Styles
+ *----------------------------------------------------*/
+st-button-editor{
+    width: 300px;
+    background-color: var(--palette-cornsik);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+st-button-editor > color-wheel{
+    position: absolute;
+}
 /* =Layout Class Styles
  * --------------------------------------------------------*/
 .list-layout {

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -1374,7 +1374,6 @@ System.registerPart('field', Field);
 System.registerPart('container', Container);
 System.registerPart('drawing', Drawing);
 System.registerPart('svg', Svg);
-Sys
 
 /** Register the initial set of views in the system **/
 System.registerView('button', ButtonView);

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -844,10 +844,16 @@ const System = {
             return;
         }
         let currentCard = this.getCurrentCardModel();
+        let currentCardView = this.findViewById(currentCard.id);
         if(partType === 'button'){
-            editor = this.newModel("button-editor", currentCard.id);
+            // Create the new view instance,
+            // append to parent, and set the target 
+            editor = document.createElement(
+                "st-button-editor"
+            );
         }
-        editor.partProperties.setPropertyNamed(editor, "targetId", partId);
+        currentCardView.appendChild(editor);
+        editor.setTarget(partId);
     },
 
     closeEditorForPart: function(partType, partId){
@@ -1368,7 +1374,7 @@ System.registerPart('field', Field);
 System.registerPart('container', Container);
 System.registerPart('drawing', Drawing);
 System.registerPart('svg', Svg);
-System.registerPart('button-editor', ButtonEditor);
+Sys
 
 /** Register the initial set of views in the system **/
 System.registerView('button', ButtonView);
@@ -1380,7 +1386,6 @@ System.registerView('field', FieldView);
 System.registerView('container', ContainerView);
 System.registerView('drawing', DrawingView);
 System.registerView('svg', SvgView);
-System.registerView('button-editor', ButtonEditorView);
 
 
 // Convenience method for adding all of the
@@ -1419,6 +1424,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Add any other non-part view CustomElements,
     // like the halo
     window.customElements.define('st-halo', Halo);
+    window.customElements.define('st-button-editor', ButtonEditorView);
 
     // Perform the initial setup of
     // the system

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -27,6 +27,7 @@ import DrawingView from './views/drawing/DrawingView.js';
 import SvgView from './views/SvgView.js';
 
 import Halo from './views/Halo.js';
+import ButtonEditorView from './views/editors/ButtonEditorView.js';
 
 import ohm from 'ohm-js';
 import interpreterSemantics from '../ohm/interpreter-semantics.js';
@@ -832,6 +833,22 @@ const System = {
             throw new Error(`Could not locate an active current stack!`);
         }
         return currentStackView.goToCardById(cardId);
+    },
+
+    openEditorForPart: function(partType, partId){
+        let currentStackModel = this.getCurrentStackModel();
+        let currentStackView = this.findViewById(currentStackModel.id);
+        let editor;
+        if(partType === 'button'){
+            editor = document.createElement("st-button-editor");
+        }
+        editor.setAttribute("data-part-id", partId);
+        currentStackView.appendChild(editor);
+    },
+
+    closeEditorForPart: function(partType, partId){
+        let editor = document.querySelector(`st-${partType}-editor[data-part-id="${partId}"]`);
+        editor.parentNode.removeChild(editor);
     }
 };
 
@@ -1396,6 +1413,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Add any other non-part view CustomElements,
     // like the halo
     window.customElements.define('st-halo', Halo);
+    window.customElements.define('st-button-editor', ButtonEditorView);
 
     // Perform the initial setup of
     // the system

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -15,6 +15,8 @@ import Container from './parts/Container.js';
 import Drawing from './parts/Drawing.js';
 import Svg from './parts/Svg.js';
 
+import ButtonEditor from './parts/editors/ButtonEditor.js';
+
 import WorldView from './views/WorldView.js';
 import StackView from './views/StackView.js';
 import ButtonView from './views/ButtonView.js';
@@ -837,21 +839,19 @@ const System = {
 
     openEditorForPart: function(partType, partId){
         // if there is already and editor open for this part do nothing
-        let editor = document.querySelector(`st-${partType}-editor[data-part-id="${partId}"]`);
+        let editor = document.querySelector(`st-${partType}-editor[target-id="${partId}"]`);
         if(editor){
             return;
         }
-        let currentStackModel = this.getCurrentStackModel();
-        let currentStackView = this.findViewById(currentStackModel.id);
+        let currentCard = this.getCurrentCardModel();
         if(partType === 'button'){
-            editor = document.createElement("st-button-editor");
+            editor = this.newModel("button-editor", currentCard.id);
         }
-        editor.setAttribute("data-part-id", partId);
-        currentStackView.appendChild(editor);
+        editor.partProperties.setPropertyNamed(editor, "targetId", partId);
     },
 
     closeEditorForPart: function(partType, partId){
-        let editor = document.querySelector(`st-${partType}-editor[data-part-id="${partId}"]`);
+        let editor = document.querySelector(`st-${partType}-editor[target-id="${partId}"]`);
         editor.parentNode.removeChild(editor);
     }
 };
@@ -1305,7 +1305,7 @@ System._commandHandlers['openScriptEditor'] = function(senders, targetId){
         'script'
     );
 
-    let htmlContent = fieldView.textToHtml(currentScript)
+    let htmlContent = fieldView.textToHtml(currentScript);
     // set the inner html of the textarea with the proper htmlContent
     // NOTE: at the moment fieldView does not subscribe to htmlContent
     // change due to cursor focus and other issues
@@ -1368,6 +1368,7 @@ System.registerPart('field', Field);
 System.registerPart('container', Container);
 System.registerPart('drawing', Drawing);
 System.registerPart('svg', Svg);
+System.registerPart('button-editor', ButtonEditor);
 
 /** Register the initial set of views in the system **/
 System.registerView('button', ButtonView);
@@ -1379,6 +1380,7 @@ System.registerView('field', FieldView);
 System.registerView('container', ContainerView);
 System.registerView('drawing', DrawingView);
 System.registerView('svg', SvgView);
+System.registerView('button-editor', ButtonEditorView);
 
 
 // Convenience method for adding all of the
@@ -1417,7 +1419,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Add any other non-part view CustomElements,
     // like the halo
     window.customElements.define('st-halo', Halo);
-    window.customElements.define('st-button-editor', ButtonEditorView);
 
     // Perform the initial setup of
     // the system

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -836,9 +836,13 @@ const System = {
     },
 
     openEditorForPart: function(partType, partId){
+        // if there is already and editor open for this part do nothing
+        let editor = document.querySelector(`st-${partType}-editor[data-part-id="${partId}"]`);
+        if(editor){
+            return;
+        }
         let currentStackModel = this.getCurrentStackModel();
         let currentStackView = this.findViewById(currentStackModel.id);
-        let editor;
         if(partType === 'button'){
             editor = document.createElement("st-button-editor");
         }

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -83,6 +83,14 @@ class Button extends Part {
             'draggable',
             true
         );
+        this.partProperties.newBasicProp(
+            'background-color',
+            null
+        );
+        this.partProperties.newBasicProp(
+            'font-color',
+            null
+        )
     }
 
     get type(){

--- a/js/objects/parts/Card.js
+++ b/js/objects/parts/Card.js
@@ -21,7 +21,7 @@ class Card extends Part {
         super(owner);
         this.stack = this._owner;
         this.acceptedSubpartTypes = [
-            "button", "field", "field", "container", "drawing", "svg"
+            "button", "button-editor", "field", "field", "container", "drawing", "svg"
         ];
         this.isCard = true;
 

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -54,6 +54,8 @@ class Part {
         this.serialize = this.serialize.bind(this);
         this.setFromDeserialized = this.setFromDeserialized.bind(this);
         this.deleteModelCmdHandler = this.deleteModelCmdHandler.bind(this);
+        this.openEditorCmdHandler = this.openEditorCmdHandler.bind(this);
+        this.closeEditorCmdHandler = this.closeEditorCmdHandler.bind(this);
         this.isSubpartOfCurrentCard = this.isSubpartOfCurrentCard.bind(this);
         this.isSubpartOfCurrentStack = this.isSubpartOfCurrentStack.bind(this);
 
@@ -64,6 +66,8 @@ class Part {
         // command handlers
         this.setPrivateCommandHandler("deleteModel", this.deleteModelCmdHandler);
         this.setPrivateCommandHandler("newModel", this.newModelCmdHandler);
+        this.setPrivateCommandHandler("openEditor", this.openEditorCmdHandler);
+        this.setPrivateCommandHandler("closeEditor", this.closeEditorCmdHandler);
     }
 
     // Convenience getter to get the id
@@ -189,6 +193,10 @@ class Part {
             new BasicProperty(
                 'backgroundColor',
                 'white'
+            ),
+            new BasicProperty(
+                'editorOpen',
+                false
             ),
             // List of (web) events the part subscribes to
             new BasicProperty(
@@ -389,6 +397,14 @@ class Part {
         Command handlers which are invoked at the Part level
         which are not immediately delegaed to the Part._owner
     **/
+
+    openEditorCmdHandler(){
+        this.partProperties.setPropertyNamed(this, 'editorOpen', true);
+    }
+
+    closeEditorCmdHandler(){
+        this.partProperties.setPropertyNamed(this, 'editorOpen', false);
+    }
 
     deleteModelCmdHandler(senders, objectId, modelType){
         if (modelType && modelType.toLowerCase() === this.type && !objectId){

--- a/js/objects/parts/editors/ButtonEditor.js
+++ b/js/objects/parts/editors/ButtonEditor.js
@@ -16,6 +16,10 @@ class ButtonEditor extends Part {
     constructor(owner, name){
         super(owner);
 
+        this.acceptedSubpartTypes = [
+            "field"
+        ];
+
         // If we are initializing with a name,
         // set the name part property
         let myName = name || `ButtonEditor ${this.id}`;

--- a/js/objects/parts/editors/ButtonEditor.js
+++ b/js/objects/parts/editors/ButtonEditor.js
@@ -1,0 +1,54 @@
+/**
+ * ButtonEditor
+ * ----------------------------------
+ * I am a ButtonEditor Part.
+ * My owner is always a Card.
+ * I am a clickable point of interaction on a Card,
+ * whose functionality can be customized by the author.
+ */
+import Part from '../Part.js';
+import {
+    BasicProperty,
+    DynamicProperty
+} from '../../properties/PartProperties.js';
+
+class ButtonEditor extends Part {
+    constructor(owner, name){
+        super(owner);
+
+        // If we are initializing with a name,
+        // set the name part property
+        let myName = name || `ButtonEditor ${this.id}`;
+        this.partProperties.setPropertyNamed(
+            this,
+            'name',
+            myName
+        );
+
+        // set up DOM events to be handled
+        this.partProperties.setPropertyNamed(
+            this,
+            'events',
+            new Set(['mousedown', 'mouseup', 'mouseenter', 'click', 'dragstart', 'dragend'])
+        );
+
+        this.partProperties.newBasicProp(
+            'targetId',
+            null 
+        );
+
+        this.isButtonEditor = true;
+
+        // Add ButtonEditor-specific part properties
+    }
+
+    get type(){
+        return 'button-editor';
+    }
+
+};
+
+export {
+    ButtonEditor,
+    ButtonEditor as default
+};

--- a/js/objects/tests/preload.js
+++ b/js/objects/tests/preload.js
@@ -18,6 +18,7 @@ global.DOMParser = window.DOMParser;
 global.alert = function alert(arg) {};
 document.execCommand = function execCommandMock() { };
 
+
 // add the grammar in
 var fs = require('fs');
 window.grammar = fs.readFileSync('./js/ohm/simpletalk.ohm');

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -35,6 +35,20 @@ describe('Button Editor tests', () => {
             let editorView = document.querySelector('st-button-editor');
             assert.isNotNull(editorView);
         });
+        it('Sending a second openEditor message does nothing', () => {
+            let sendFunction = function(){
+                let msg = {
+                    type: 'command',
+                    commandName: 'openEditor',
+                    args: []
+                };
+                button.sendMessage(msg, button);
+            };
+            expect(sendFunction).to.not.throw();
+            // TODO 
+            let editorViews = document.querySelectorAll('st-button-editor');
+            assert.equal(editorViews.length, 1);
+        });
         it('Sending an closeEditor message closes the editor', () => {
             let sendFunction = function(){
                 let msg = {

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -31,16 +31,30 @@ describe('Button Editor tests', () => {
                 button.sendMessage(msg, button);
             };
             expect(sendFunction).to.not.throw();
-            // TODO 
             let editorView = document.querySelector('st-button-editor');
             assert.isNotNull(editorView);
         });
-        it('Editor model and view have the proper target ids', () => {
+        it.skip('Editor model and view have the proper target ids', () => {
             let editorView = document.querySelector('st-button-editor');
             let editorModel = editorView.model;
             let targetId = editorModel.partProperties.getPropertyNamed(editorModel, "targetId");
             assert.equal(targetId, button.id);
             assert.equal(targetId, editorView.getAttribute("target-id"));
+        });
+        it.skip('Clicking the Editor script button opens text field', () => {
+            let editorView = document.querySelector('st-button-editor');
+            let button = editorView.querySelector('.edit-script-button');
+            let clickEvent = new window.MouseEvent('click');
+            let clickEventFunc = function(){
+                button.dispatchEvent(clickEvent);
+            };
+            let fieldView = editorView.querySelector('st-field');
+            expect(clickEventFunc).to.not.throw(Error);
+            assert.isNotNull(fieldView);
+        });
+        it.skip('Script editor target is correct', () => {
+            //TODO this really can't be done at the moment due to how
+            // script editor is constructed but should be in the future
         });
         it('Sending a second openEditor message does nothing', () => {
             let sendFunction = function(){
@@ -52,7 +66,6 @@ describe('Button Editor tests', () => {
                 button.sendMessage(msg, button);
             };
             expect(sendFunction).to.not.throw();
-            // TODO 
             let editorViews = document.querySelectorAll('st-button-editor');
             assert.equal(editorViews.length, 1);
         });

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -10,6 +10,18 @@ const expect = chai.expect;
 describe('Button Editor tests', () => {
     let currentCard = System.getCurrentCardModel();
     let button = System.newModel("button", currentCard.id);
+    let buttonScript = 'on click\n    answer "ok"\nend click';
+    let buttonName = 'a cool button';
+    button.partProperties.setPropertyNamed(
+        button,
+        'script',
+        buttonScript
+    );
+    button.partProperties.setPropertyNamed(
+        button,
+        'name',
+        buttonName
+    );
     describe('System initialialization', () => {
         it('All parts are present', () => {
             assert.exists(currentCard);
@@ -34,6 +46,11 @@ describe('Button Editor tests', () => {
             let editorView = document.querySelector('st-button-editor');
             assert.isNotNull(editorView);
         });
+        it('Editor title bar has the proper name', () => {
+            let editorView = document.querySelector('st-button-editor');
+            let title = editorView._shadowRoot.querySelector('.editor-title > span');
+            assert.equal(title.textContent, buttonName);
+        });
         it.skip('Editor model and view have the proper target ids', () => {
             let editorView = document.querySelector('st-button-editor');
             let editorModel = editorView.model;
@@ -41,20 +58,27 @@ describe('Button Editor tests', () => {
             assert.equal(targetId, button.id);
             assert.equal(targetId, editorView.getAttribute("target-id"));
         });
-        it.skip('Clicking the Editor script button opens text field', () => {
+        it('Clicking the Editor script button opens field', () => {
             let editorView = document.querySelector('st-button-editor');
-            let button = editorView.querySelector('.edit-script-button');
+            let button = editorView._shadowRoot.querySelector('button.script');
             let clickEvent = new window.MouseEvent('click');
-            let clickEventFunc = function(){
-                button.dispatchEvent(clickEvent);
-            };
-            let fieldView = editorView.querySelector('st-field');
-            expect(clickEventFunc).to.not.throw(Error);
+            button.dispatchEvent(clickEvent);
+            let fieldView = document.querySelector('st-field');
             assert.isNotNull(fieldView);
         });
-        it.skip('Script editor target is correct', () => {
-            //TODO this really can't be done at the moment due to how
-            // script editor is constructed but should be in the future
+        it('Script editor target is correct (has the correct script)', () => {
+            // TODO return to this when we have better script editor target attribution
+            let fieldView = document.querySelector('st-field');
+            let textArea = fieldView._shadowRoot.querySelector('.field-textarea');
+            // you can't use textArea.innerText here so we need to replace the newlines
+            // to check for equivalence
+            assert.equal(textArea.textContent, buttonScript.replace(/\n/g, ''));
+
+        });
+        it('Button name is default displayed', () => {
+            let editorView = document.querySelector('st-button-editor');
+            let input = editorView._shadowRoot.querySelector('input.name');
+            assert.equal(input.defaultValue, buttonName);
         });
         it('Sending a second openEditor message does nothing', () => {
             let sendFunction = function(){

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -79,7 +79,7 @@ describe('Button Editor tests', () => {
         it('Button name is default displayed', () => {
             let editorView = document.querySelector('st-button-editor');
             let input = editorView._shadowRoot.querySelector('input.name');
-            assert.equal(input.defaultValue, buttonName);
+            assert.equal(input.placeholder, buttonName);
         });
         it('Text input changes the button name as desired', () => {
             let newName = "a cooler button";
@@ -120,7 +120,7 @@ describe('Button Editor tests', () => {
             let anEventName = buttonEvents.values().next().value;
             let eventEl = eventList.querySelector(`#${anEventName}`);
             assert.isNotNull(eventEl);
-            let removeX = eventEl.querySelector('svg');
+            let removeX = eventEl.querySelector('span.remove');
             let clickEvent = new window.MouseEvent('click');
             removeX.dispatchEvent(clickEvent);
             eventEl = eventList.querySelector(`#${anEventName}`);

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -35,6 +35,13 @@ describe('Button Editor tests', () => {
             let editorView = document.querySelector('st-button-editor');
             assert.isNotNull(editorView);
         });
+        it('Editor model and view have the proper target ids', () => {
+            let editorView = document.querySelector('st-button-editor');
+            let editorModel = editorView.model;
+            let targetId = editorModel.partProperties.getPropertyNamed(editorModel, "targetId");
+            assert.equal(targetId, button.id);
+            assert.equal(targetId, editorView.getAttribute("target-id"));
+        });
         it('Sending a second openEditor message does nothing', () => {
             let sendFunction = function(){
                 let msg = {

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -1,0 +1,102 @@
+/**
+ * Editor Tests
+ * -----------------------------------------
+ * Integration test for various part editors
+ */
+import chai from 'chai';
+const assert = chai.assert;
+
+describe('Button Editor tests', () => {
+    describe('System initialialization', () => {
+        it('Has loaded set to true', () => {
+            assert.isTrue(System.isLoaded);
+        });
+        it('Has created a world view element', () => {
+            let foundEl = document.querySelector('st-world');
+            assert.exists(foundEl);
+        });
+        it('Can locate the current stack', () => {
+            let foundEl = document.querySelector('.current-stack');
+            assert.exists(foundEl);
+            assert.exists(foundEl.model);
+        });
+        it('Can locate the (only) current card in the stack', () => {
+            let foundEl = document.querySelector('st-card.current-card');
+            assert.exists(foundEl);
+            assert.exists(foundEl.model);
+        });
+        it('Can get card view by its id', () => {
+            let cardEl = document.querySelector('st-card.current-card');
+            let id = cardEl.getAttribute('part-id');
+            let found = document.querySelector(`[part-id="${id}"]`);
+            assert.equal(id, "2");
+            assert.exists(found);
+        });
+    });
+
+    describe('Adding the button that will be tested', () => {
+        var buttonModel;
+        it('Can add the button via System message', () => {
+            let stackEl = document.querySelector('.current-stack');
+            let cardEl = stackEl.querySelector('st-card');
+            let msg = {
+                type: "command",
+                commandName: "newModel",
+                args: ["button", cardEl.model.id]
+            };
+            System.receiveMessage(msg);
+            let btnEl = cardEl.querySelector('st-button');
+            assert.exists(btnEl);
+            buttonModel = btnEl.model;
+            assert.exists(buttonModel);
+        });
+        describe('#mouseEnter', () => {
+            it('Triggering mouseEnter on the ButtonView element sends the mouseEnter msg to System', () => {
+                let buttonView = document.querySelector('st-button');
+                let event = new window.MouseEvent('mouseenter');
+                assert.doesNotThrow(
+                    buttonView.dispatchEvent.bind(buttonView, event),
+                    Error
+                );
+            });
+
+            it('Button can capture the mouseEnter message', () => {
+                let result = 0;
+                let handler = function(){
+                    result = 1;
+                };
+                let buttonView = document.querySelector('st-button');
+                let buttomModel = buttonView.model;
+                buttonModel._commandHandlers['mouseEnter'] = handler;
+                let event = new window.MouseEvent('mouseenter');
+                buttonView.dispatchEvent(event);
+
+                assert.equal(1, result);
+            });
+        });
+        describe('#mouseUp', () => {
+            it('Triggering mouseUp on the ButtonView element sends the mouseEnter msg to System', () => {
+                let buttonView = document.querySelector('st-button');
+                let event = new window.MouseEvent('mouseup');
+                assert.doesNotThrow(
+                    buttonView.dispatchEvent.bind(buttonView, event),
+                    Error
+                );
+            });
+
+            it('Button can capture the mouseUp message', () => {
+                let result = 0;
+                let handler = function(){
+                    result = 1;
+                };
+                let buttonView = document.querySelector('st-button');
+                let buttomModel = buttonView.model;
+                buttonModel._commandHandlers['mouseUp'] = handler;
+                let event = new window.MouseEvent('mouseup');
+                buttonView.dispatchEvent(event);
+
+                assert.equal(1, result);
+            });
+        });
+    });
+});

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -5,98 +5,50 @@
  */
 import chai from 'chai';
 const assert = chai.assert;
+const expect = chai.expect;
 
 describe('Button Editor tests', () => {
+    let currentCard = System.getCurrentCardModel();
+    let button = System.newModel("button", currentCard.id);
     describe('System initialialization', () => {
-        it('Has loaded set to true', () => {
-            assert.isTrue(System.isLoaded);
+        it('All parts are present', () => {
+            assert.exists(currentCard);
+            assert.exists(button);
         });
-        it('Has created a world view element', () => {
-            let foundEl = document.querySelector('st-world');
-            assert.exists(foundEl);
+        it('editorOpen prop is false and no editor is present', () => {
+            let editorOpenProp = button.partProperties.getPropertyNamed(button, "editorOpen");
+            assert.isFalse(editorOpenProp);
+            let editorView = document.querySelector('st-button-editor');
+            assert.isNull(editorView);
         });
-        it('Can locate the current stack', () => {
-            let foundEl = document.querySelector('.current-stack');
-            assert.exists(foundEl);
-            assert.exists(foundEl.model);
-        });
-        it('Can locate the (only) current card in the stack', () => {
-            let foundEl = document.querySelector('st-card.current-card');
-            assert.exists(foundEl);
-            assert.exists(foundEl.model);
-        });
-        it('Can get card view by its id', () => {
-            let cardEl = document.querySelector('st-card.current-card');
-            let id = cardEl.getAttribute('part-id');
-            let found = document.querySelector(`[part-id="${id}"]`);
-            assert.equal(id, "2");
-            assert.exists(found);
-        });
-    });
-
-    describe('Adding the button that will be tested', () => {
-        var buttonModel;
-        it('Can add the button via System message', () => {
-            let stackEl = document.querySelector('.current-stack');
-            let cardEl = stackEl.querySelector('st-card');
-            let msg = {
-                type: "command",
-                commandName: "newModel",
-                args: ["button", cardEl.model.id]
+        it('Sending an openEditor message opens the editor', () => {
+            let sendFunction = function(){
+                let msg = {
+                    type: 'command',
+                    commandName: 'openEditor',
+                    args: []
+                };
+                button.sendMessage(msg, button);
             };
-            System.receiveMessage(msg);
-            let btnEl = cardEl.querySelector('st-button');
-            assert.exists(btnEl);
-            buttonModel = btnEl.model;
-            assert.exists(buttonModel);
+            expect(sendFunction).to.not.throw();
+            // TODO 
+            let editorView = document.querySelector('st-button-editor');
+            assert.isNotNull(editorView);
         });
-        describe('#mouseEnter', () => {
-            it('Triggering mouseEnter on the ButtonView element sends the mouseEnter msg to System', () => {
-                let buttonView = document.querySelector('st-button');
-                let event = new window.MouseEvent('mouseenter');
-                assert.doesNotThrow(
-                    buttonView.dispatchEvent.bind(buttonView, event),
-                    Error
-                );
-            });
-
-            it('Button can capture the mouseEnter message', () => {
-                let result = 0;
-                let handler = function(){
-                    result = 1;
+        it('Sending an closeEditor message closes the editor', () => {
+            let sendFunction = function(){
+                let msg = {
+                    type: 'command',
+                    commandName: 'closeEditor',
+                    args: []
                 };
-                let buttonView = document.querySelector('st-button');
-                let buttomModel = buttonView.model;
-                buttonModel._commandHandlers['mouseEnter'] = handler;
-                let event = new window.MouseEvent('mouseenter');
-                buttonView.dispatchEvent(event);
-
-                assert.equal(1, result);
-            });
+                button.sendMessage(msg, button);
+            };
+            expect(sendFunction).to.not.throw();
+            // TODO 
+            let editorView = document.querySelector('st-button-editor');
+            assert.isNull(editorView);
         });
-        describe('#mouseUp', () => {
-            it('Triggering mouseUp on the ButtonView element sends the mouseEnter msg to System', () => {
-                let buttonView = document.querySelector('st-button');
-                let event = new window.MouseEvent('mouseup');
-                assert.doesNotThrow(
-                    buttonView.dispatchEvent.bind(buttonView, event),
-                    Error
-                );
-            });
 
-            it('Button can capture the mouseUp message', () => {
-                let result = 0;
-                let handler = function(){
-                    result = 1;
-                };
-                let buttonView = document.querySelector('st-button');
-                let buttomModel = buttonView.model;
-                buttonModel._commandHandlers['mouseUp'] = handler;
-                let event = new window.MouseEvent('mouseup');
-                buttonView.dispatchEvent(event);
-
-                assert.equal(1, result);
-            });
-        });
     });
 });

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -7,6 +7,7 @@ import chai from 'chai';
 const assert = chai.assert;
 const expect = chai.expect;
 
+
 describe('Button Editor tests', () => {
     let currentCard = System.getCurrentCardModel();
     let button = System.newModel("button", currentCard.id);
@@ -49,7 +50,7 @@ describe('Button Editor tests', () => {
         it('Editor title bar has the proper name', () => {
             let editorView = document.querySelector('st-button-editor');
             let title = editorView._shadowRoot.querySelector('.editor-title > span');
-            assert.equal(title.textContent, buttonName);
+            assert.equal(title.textContent, `Button Editor [${buttonName}]`);
         });
         it.skip('Editor model and view have the proper target ids', () => {
             let editorView = document.querySelector('st-button-editor');
@@ -80,6 +81,67 @@ describe('Button Editor tests', () => {
             let input = editorView._shadowRoot.querySelector('input.name');
             assert.equal(input.defaultValue, buttonName);
         });
+        it('Text input changes the button name as desired', () => {
+            let newName = "a cooler button";
+            let editorView = document.querySelector('st-button-editor');
+            let input = editorView._shadowRoot.querySelector('input.name');
+            input.value = newName;
+            let inputEvent = new window.MouseEvent('input');
+            input.dispatchEvent(inputEvent);
+            assert.equal(newName, button.partProperties.getPropertyNamed(button, 'name'));
+            let title = editorView._shadowRoot.querySelector('.editor-title > span');
+            assert.equal(title.textContent, `Button Editor [${newName}]`);
+        });
+        it('Color wheel buttons are present', () => {
+            // TODO technically we should test the interface here, but need to
+            // implement mock canvas before
+            let editorView = document.querySelector('st-button-editor');
+            let buttonBG = editorView._shadowRoot.querySelector('button.background-color');
+            assert.isNotNull(buttonBG);
+            let buttonFont = editorView._shadowRoot.querySelector('button.font-color');
+            assert.isNotNull(buttonFont);
+        });
+        it('All default button events are present', () => {
+            let editorView = document.querySelector('st-button-editor');
+            let eventList = editorView._shadowRoot.querySelector('div.event-list');
+            let defaultEvents = button.partProperties.getPropertyNamed(button, 'events');
+            // here we are making an assumption that there is at least one button event
+            assert.isAbove(defaultEvents.size, 0);
+            defaultEvents.forEach((e) => {
+                eventList.querySelector(`#${e}`);
+                assert.isNotNull(e);
+            });
+        });
+        it('Removing an event removes from the partProperties and the editor', () => {
+            let editorView = document.querySelector('st-button-editor');
+            let eventList = editorView._shadowRoot.querySelector('div.event-list');
+            let buttonEvents = button.partProperties.getPropertyNamed(button, 'events');
+            // here we are making an assumption that there is at least one button event
+            let anEventName = buttonEvents.values().next().value;
+            let eventEl = eventList.querySelector(`#${anEventName}`);
+            assert.isNotNull(eventEl);
+            let removeX = eventEl.querySelector('svg');
+            let clickEvent = new window.MouseEvent('click');
+            removeX.dispatchEvent(clickEvent);
+            eventEl = eventList.querySelector(`#${anEventName}`);
+            assert.isNull(eventEl);
+            buttonEvents = button.partProperties.getPropertyNamed(button, 'events');
+            assert.isFalse(buttonEvents.has(anEventName));
+        });
+        it('Adding an event adds to the partProperties and the editor', () => {
+            let newEvent = "MyNewEvent";
+            let editorView = document.querySelector('st-button-editor');
+            let eventList = editorView._shadowRoot.querySelector('div.event-list');
+            let inputEl = editorView._shadowRoot.querySelector('input.events');
+            inputEl.value = newEvent;
+            let keydownEvent = new window.MouseEvent('keydown');
+            keydownEvent.code = 'Enter';
+            inputEl.dispatchEvent(keydownEvent);
+            let eventEl = eventList.querySelector(`#${newEvent}`);
+            assert.isNotNull(eventEl);
+            let buttonEvents = button.partProperties.getPropertyNamed(button, 'events');
+            assert.isTrue(buttonEvents.has(newEvent));
+        });
         it('Sending a second openEditor message does nothing', () => {
             let sendFunction = function(){
                 let msg = {
@@ -93,8 +155,26 @@ describe('Button Editor tests', () => {
             let editorViews = document.querySelectorAll('st-button-editor');
             assert.equal(editorViews.length, 1);
         });
+        it('Clicking the close button closes the editor', () => {
+            let editorView = document.querySelector('st-button-editor');
+            let button = editorView._shadowRoot.querySelector('div.close-button');
+            let clickEvent = new window.MouseEvent('click');
+            button.dispatchEvent(clickEvent);
+            editorView = document.querySelector('st-button-editor');
+            assert.isNull(editorView);
+        });
         it('Sending an closeEditor message closes the editor', () => {
+            // First open the editor again
             let sendFunction = function(){
+                let msg = {
+                    type: 'command',
+                    commandName: 'openEditor',
+                    args: []
+                };
+                button.sendMessage(msg, button);
+            };
+            expect(sendFunction).to.not.throw();
+            sendFunction = function(){
                 let msg = {
                     type: 'command',
                     commandName: 'closeEditor',
@@ -102,8 +182,8 @@ describe('Button Editor tests', () => {
                 };
                 button.sendMessage(msg, button);
             };
+
             expect(sendFunction).to.not.throw();
-            // TODO 
             let editorView = document.querySelector('st-button-editor');
             assert.isNull(editorView);
         });

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -4,6 +4,7 @@
  * I am a webcomponent representing a Button.
  */
 import PartView from './PartView.js';
+import ButtonEditorView from './editors/ButtonEditorView.js'
 
 const templateString = `
                 <style>
@@ -76,6 +77,20 @@ class ButtonView extends PartView {
         this['onclick'] = null;
         this['ondragstart'] = null;
         this['ondragend'] = null;
+    }
+
+    // We overwrite the PartView.onHaloOpenEditor for the moment
+    // TODO when all editors are properly established this can
+    // be moved back to the base class, and remove from here
+    onHaloOpenEditor(){
+        // Send the message to open a script editor
+        // with this view's model as the target
+        this.model.sendMessage({
+            type: 'command',
+            commandName: 'openEditor',
+            args: [this.model.id],
+            shouldIgnore: true // Should ignore if System DNU
+        }, this.model);
     }
 
     onClick(event){
@@ -152,6 +167,15 @@ class ButtonView extends PartView {
     onDragend(event){
         this.classList.remove('active');
     };
+
+    // Overwriting the base class open/close editor methods
+    openEditor(){
+        window.System.openEditorForPart("button", this.model.id);
+    }
+
+    closeEditor(){
+        window.System.closeEditorForPart("button", this.model.id);
+    }
 };
 
 export {

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -47,6 +47,12 @@ class ButtonView extends PartView {
         this.onPropChange('name', (value, partId) => {
             this.innerText = value;
         });
+        this.onPropChange('background-color', (value) => {
+            this.style.backgroundColor = value;
+        });
+        this.onPropChange('font-color', (value) =>{
+            this.style.color = value;
+        });
         this.onPropChange("draggable", (value) => {
             this.setAttribute('draggable', value);
         });

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -4,7 +4,6 @@
  * I am a webcomponent representing a Button.
  */
 import PartView from './PartView.js';
-import ButtonEditorView from './editors/ButtonEditorView.js'
 
 const templateString = `
                 <style>

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -321,7 +321,7 @@ class FieldView extends PartView {
                 if(command === "fontsize"){
                     eventName = "change";
                 }
-                node.addEventListener(eventName, (event) => {this._toolbarHandler(event, command, value);})
+                node.addEventListener(eventName, (event) => {this._toolbarHandler(event, command, value);});
             }
         });
     }
@@ -356,7 +356,7 @@ class FieldView extends PartView {
         colorWheelWidget.setAttribute("selector-command", command);
         // add a custom callback for the close button
         let closeButton = colorWheelWidget.shadowRoot.querySelector('#close-button');
-        closeButton.addEventListener('click', () => {colorWheelWidget.remove()});
+        closeButton.addEventListener('click', () => {colorWheelWidget.remove();});
         // add the colorWheelWidget
         event.target.parentNode.after(colorWheelWidget);
         // add a color-selected event callback

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -43,6 +43,7 @@ const templateString = `
      left: calc(-1 * var(--halo-button-width-padded));
      width: calc(100% + (2 * var(--halo-button-width-padded)));
      height: calc(100% + (2 * var(--halo-button-height-padded)));
+     color: initial;
  }
 
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -47,6 +47,10 @@ class PartView extends HTMLElement {
         this.onHaloDelete = this.onHaloDelete.bind(this);
         this.onHaloOpenEditor = this.onHaloOpenEditor.bind(this);
 
+        // Bind editor related methods
+        this.openEditor = this.openEditor.bind(this);
+        this.closeEditor = this.closeEditor.bind(this);
+
         // Bind lifecycle methods
         this.afterModelSet = this.afterModelSet.bind(this);
         this.afterConnected = this.afterConnected.bind(this);
@@ -98,6 +102,13 @@ class PartView extends HTMLElement {
         this.onPropChange('script', this.scriptChanged);
         this.onPropChange('eventRespond', this.eventRespond);
         this.onPropChange('eventIgnore', this.eventIgnore);
+        this.onPropChange('editorOpen', (value) => {
+            if(value === true){
+                this.openEditor();
+            } else if(value === false){
+                this.closeEditor();
+            }
+        });
     }
 
     sendMessage(aMessage, target){
@@ -280,7 +291,16 @@ class PartView extends HTMLElement {
         return false;
     }
 
+    /* Editor related methods */
+    openEditor(){
+        // Does nothing by default.
+        // Should be implemented in subclass
+    }
 
+    closeEditor(){
+        // Does nothing by default.
+        // Should be implemented in subclass
+    }
 };
 
 export {

--- a/js/objects/views/drawing/ColorWheelWidget.js
+++ b/js/objects/views/drawing/ColorWheelWidget.js
@@ -44,6 +44,8 @@ const colorWheelTemplate = `
     margin-left: 8px;
     background-color: white;
     border: 1px solid black;
+    text-align: center;
+    font-size: 12px;
   }
 
   #palette-content {
@@ -81,7 +83,7 @@ const colorWheelTemplate = `
 
 </style>
 <div id="palette-wrapper">
-  <div id="palette-bar"><div id="close-button"></div><span id="palette-title"></span></div>
+  <div id="palette-bar"><div id="close-button">x</div><span id="palette-title"></span></div>
   <div id="palette-content">
     <ul id="recent-colors">
       <li class="recent-color-item selected"></li>

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -1,4 +1,6 @@
-import PartView from '../PartView.js';
+import ColorWheelWidget from '../drawing/ColorWheelWidget.js';
+
+const closeIcon = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-square-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M10 10l4 4m0 -4l-4 4"></path></svg>`;
 
 const templateString = `
 <style>
@@ -61,18 +63,16 @@ const templateString = `
 <div class="editor-main">
     <input class="name"></input>
     <button class="script">Script</button>
-    <button class="background-color">Background Color</button>
-    <button class="font-color">Font Color</button>
-    <div class="events">
-        <input type="checkbox" id="click" name="click" checked>
-        <label for="click">click</label>
-        <input type="checkbox" id="mouseenter" name="mouseenter">
-        <label for="mouseenter">mouseenter</label>
-        <input type="checkbox" id="mouseover" name="mouseover">
-        <label for="mouseenter">mouseover</label>
+    <button class="background-color" name="background-color">Background Color</button>
+    <button class="font-color" name="font-color">Font Color</button>
+    <div class="events-display">
+        <input class="events"></input>
+        <div class="event-list"></div>
     </div>
 </div>
 `;
+
+const SVGParser = new DOMParser();
 
 class ButtonEditorView extends HTMLElement {
     constructor(){
@@ -96,11 +96,19 @@ class ButtonEditorView extends HTMLElement {
         this.setupClickAndDrag = this.setupClickAndDrag.bind(this);
         // this.setupBarButtons = this.setupBarButtons.bind(this);
         // this.setupExpanderAreas = this.setupExpanderAreas.bind(this);
+        this.openColorWheelWidget = this.openColorWheelWidget.bind(this);
+        this.onColorSelected = this.onColorSelected.bind(this);
         this.onMouseDownInBar = this.onMouseDownInBar.bind(this);
         this.onMouseUpAfterDrag = this.onMouseUpAfterDrag.bind(this);
         this.onMouseMoveInBar = this.onMouseMoveInBar.bind(this);
         this.onScriptButtonClick = this.onScriptButtonClick.bind(this);
-
+        this.onCloseButtonClick = this.onCloseButtonClick.bind(this);
+        this.onNameInput = this.onNameInput.bind(this);
+        this.onIgnoreEvent = this.onIgnoreEvent.bind(this);
+        this.onEventInputKeydown = this.onEventInputKeydown.bind(this);
+        this.respondToEvent = this.respondToEvent.bind(this);
+        this._displayEvent = this._displayEvent.bind(this);
+        this._removeEvent = this._removeEvent.bind(this);
     }
 
 
@@ -116,8 +124,18 @@ class ButtonEditorView extends HTMLElement {
     }
 
     disconnectedCallback(){
+        let closeButton = this._shadowRoot.querySelector('div.close-button');
+        closeButton.removeEventListener('click', this.onCloseButtonClick);
         let scriptButton = this._shadowRoot.querySelector('button.script');
         scriptButton.removeEventListener('click', this.onScriptButtonClick);
+        let nameInput = this._shadowRoot.querySelector('input.name');
+        nameInput.removeEventListener('input', this.onNameInput);
+        let backgroundButton = this._shadowRoot.querySelector('button.background-color');
+        backgroundButton.removeEventListener('click', this.openColorWheelWidget);
+        let colorButton = this._shadowRoot.querySelector('button.font-color');
+        let eventsDiv = this._shadowRoot.querySelector('.editor-main > div.events-display');
+        let eventsInput = eventsDiv.querySelector('input.events');
+        eventsInput.removeEventListener('keydown', this.onEventInputKeydown);
     }
 
     setTarget(partId){
@@ -135,8 +153,16 @@ class ButtonEditorView extends HTMLElement {
         let name = this.target.partProperties.getPropertyNamed(this.target, 'name');
         let titleSpan = this._shadowRoot.querySelector('.editor-title > span');
         let nameInput = this._shadowRoot.querySelector('input.name');
-        titleSpan.textContent = name;
+        titleSpan.textContent = `Button Editor [${name}]`;
         nameInput.defaultValue = name;
+        // set up events editing interface
+        let currentEvents = this.target.partProperties.getPropertyNamed(this.target, "events");
+        let eventsDiv = this._shadowRoot.querySelector('.editor-main > div.events-display');
+        let eventsInput = eventsDiv.querySelector('input.events');
+        eventsInput.placeholder = "Add event name";
+        currentEvents.forEach((e) => {
+            this._displayEvent(e);
+        });
     }
 
     /*
@@ -145,9 +171,39 @@ class ButtonEditorView extends HTMLElement {
     */
     setupChangeHandlers(){
         // scripting
+        let closeButton = this._shadowRoot.querySelector('div.close-button');
+        closeButton.addEventListener('click', this.onCloseButtonClick);
         let scriptButton = this._shadowRoot.querySelector('button.script');
         scriptButton.addEventListener('click', this.onScriptButtonClick);
+        let nameInput = this._shadowRoot.querySelector('input.name');
+        nameInput.addEventListener('input', this.onNameInput);
+        let backgroundButton = this._shadowRoot.querySelector('button.background-color');
+        backgroundButton.addEventListener('click', this.openColorWheelWidget);
+        let colorButton = this._shadowRoot.querySelector('button.font-color');
+        colorButton.addEventListener('click', this.openColorWheelWidget);
+        let eventsDiv = this._shadowRoot.querySelector('.editor-main > div.events-display');
+        let eventsInput = eventsDiv.querySelector('input.events');
+        eventsInput.addEventListener('keydown', this.onEventInputKeydown);
     }
+
+    onNameInput(event){
+        let titleSpan = this._shadowRoot.querySelector('.editor-title > span');
+        titleSpan.textContent = `Button Editor [${event.target.value}]`;
+        this.target.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["name", event.target.value]
+        }, this.target);
+    }
+
+    onCloseButtonClick(){
+        this.target.sendMessage({
+            type: "command",
+            commandName: "closeEditor",
+            args: [this.target.id]
+        }, this.target);
+    }
+
 
     onScriptButtonClick(){
         this.target.sendMessage({
@@ -155,6 +211,56 @@ class ButtonEditorView extends HTMLElement {
             commandName: "openScriptEditor",
             args: [this.target.id]
         }, this.target);
+    }
+
+    openColorWheelWidget(event){
+        let colorWheelWidget = new ColorWheelWidget(event.target.name);
+        // add an attribute describing the command
+        colorWheelWidget.setAttribute("selector-command", event.target.name);
+        // add a custom callback for the close button
+        let closeButton = colorWheelWidget.shadowRoot.querySelector('#close-button');
+        closeButton.addEventListener('click', () => {colorWheelWidget.remove();});
+        // add the colorWheelWidget
+        event.target.parentNode.after(colorWheelWidget);
+        // add a color-selected event callback
+        // colorWheelWidget event listener
+        let colorWheel = this.shadowRoot.querySelector('color-wheel');
+        colorWheel.addEventListener('color-selected', this.onColorSelected);
+    }
+
+    onColorSelected(event){
+        let command = event.target.getAttribute("selector-command");
+        let colorInfo = event.detail;
+        let colorStr = `rgba(${colorInfo.r}, ${colorInfo.g}, ${colorInfo.b}, ${colorInfo.alpha})`;
+        this.target.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: [command, colorStr]
+        }, this.target);
+    }
+
+    onIgnoreEvent(event){
+        this.target.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["eventIgnore", event.target.name]
+        }, this.target);
+        this._removeEvent(event.target.name);
+    }
+
+    onEventInputKeydown(event){
+        if(event.code === "Enter"){
+            this.respondToEvent(event.target.value);
+        }
+    }
+
+    respondToEvent(eventName){
+        this.target.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["eventRespond", eventName]
+        }, this.target);
+        this._displayEvent(eventName);
     }
 
     setupClickAndDrag(){
@@ -185,6 +291,26 @@ class ButtonEditorView extends HTMLElement {
         this.style.left = newLeft;
     }
 
+    _displayEvent(eventName){
+        let eventListDiv = this._shadowRoot.querySelector('div.event-list');
+        let eventEl = document.createElement("div");
+        let eventSpan = document.createElement("span");
+        let xmlDocument = SVGParser.parseFromString(closeIcon, 'application/xml');
+        let closeSvgEl = xmlDocument.documentElement;
+        closeSvgEl.name = eventName;
+        eventEl.id = eventName;
+        closeSvgEl.addEventListener('click', this.onIgnoreEvent);
+        eventSpan.textContent = eventName;
+        eventEl.appendChild(closeSvgEl);
+        eventEl.appendChild(eventSpan);
+        eventListDiv.appendChild(eventEl);
+    }
+
+    _removeEvent(eventName){
+        let eventListDiv = this._shadowRoot.querySelector('div.event-list');
+        let eventEl = eventListDiv.querySelector(`#${eventName}`);
+        eventListDiv.removeChild(eventEl);
+    }
 };
 
 export {

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -1,0 +1,32 @@
+import PartView from '../PartView.js';
+
+const templateString = `
+   <st-container></st-container>
+`;
+
+class ButtonEditorView extends PartView {
+    constructor(){
+        super();
+        this.defaultWidth = "100px";
+        this.defaultHeight = "100px";
+
+        this.template = document.createElement('template');
+        this.template.innerHTML = templateString;
+        this._shadowRoot = this.attachShadow({mode: 'open'});
+        this._shadowRoot.appendChild(this.template.content.cloneNode(true));
+    }
+
+    afterModelSet() {
+    }
+
+    afterConnected(){
+    }
+
+    afterDisconnected(){
+    }
+};
+
+export {
+    ButtonEditorView,
+    ButtonEditorView as default
+};

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -1,33 +1,134 @@
 import PartView from '../PartView.js';
 
 const templateString = `
-   <st-container></st-container>
+<style>
+    :host {
+        position: absolute;
+        box-sizing: border-box;
+        top: 200px;
+        left: 200px;
+        min-width: 300px;
+        min-height: 200px;
+    }
+
+    .st-field-bar {
+        display: flex;
+        flex-direction: row;
+        height: 25px;
+        background-color: rgb(218, 218, 218);
+        padding-left: 8px;
+        padding-right: 8px;
+        align-items: center;
+    }
+
+    .st-field-main {
+        display: flex;
+        flex-direction: row;
+        min-height: 200px;
+    }
+
+    .st-field-main > * {
+       width: 50%;
+    }
+
+    .st-field-button {
+        display: block;
+        width: 12px;
+        height: 12px;
+        border-radius: 100%;
+        background-color: rgba(255, 150, 150);
+        margin-right: 4px;
+    }
+    .close-button {
+        background-color: rgba(255, 50, 50, 0.4);
+    }
+
+    :st-field{
+        position: relative;
+        height: 100%;
+    }
+</style>
+<div class="st-field-bar">
+    <div class="st-field-button close-button"></div>
+    <div class="st-field-title">
+        <span></span>
+    </div>
+</div>
+<div class="st-field-main">
+    <div class="st-field-pane-general">
+        <slot></slot>
+    </div>
+    <div class="st-field-pane-editor">
+        <st-field></st-field>
+    </div>
+</div>
 `;
 
 class ButtonEditorView extends PartView {
     constructor(){
         super();
-        this.defaultWidth = "100px";
-        this.defaultHeight = "100px";
-
 
         // Configure the Shadow DOM and template
         this.template = document.createElement('template');
         this.template.innerHTML = templateString;
-        this.shadow = this.attachShadow({mode: 'open'});
-        this.shadow.append(
+        this._shadowRoot = this.attachShadow({mode: 'open'});
+        this._shadowRoot.appendChild(
             this.template.content.cloneNode(true)
         );
+
+        this.mouseDownInBar = false;
+
+        // bind methods
+        this.setupClickAndDrag = this.setupClickAndDrag.bind(this);
+        // this.setupBarButtons = this.setupBarButtons.bind(this);
+        // this.setupExpanderAreas = this.setupExpanderAreas.bind(this);
+        this.onMouseMoveInBar = this.onMouseMoveInBar.bind(this);
+        this.onMouseDownInBar = this.onMouseDownInBar.bind(this);
+        this.onMouseUpAfterDrag = this.onMouseUpAfterDrag.bind(this);
     }
 
     afterModelSet() {
     }
 
     afterConnected(){
+        this.setupClickAndDrag();
+        // this.setupBarButtons();
+        // this.setupExpanderAreas();
+        this.style.top = "50px";
+        this.style.left = "50px";
     }
 
     afterDisconnected(){
     }
+
+    setupClickAndDrag(){
+        let bar = this._shadowRoot.querySelector('.st-field-bar');
+        bar.addEventListener('mousedown', this.onMouseDownInBar);
+    }
+
+    onMouseDownInBar(event){
+        this.mouseDownInBar = true;
+        let bar = event.target;
+        document.addEventListener('mousemove', this.onMouseMoveInBar);
+        document.addEventListener('mouseup', this.onMouseUpAfterDrag);
+    }
+
+    onMouseUpAfterDrag(event){
+        this.mouseDownInBar = false;
+        let bar = event.target;
+        document.removeEventListener('mouseup', this.onMouseUpAfterDrag);
+        document.removeEventListener('mousemove', this.onMouseMoveInBar);
+    }
+
+    onMouseMoveInBar(event){
+        let currentTop = parseInt(this.style.top);
+        let currentLeft = parseInt(this.style.left);
+        let newTop = `${currentTop + event.movementY}px`;
+        let newLeft = `${currentLeft + event.movementX}px`;
+        this.style.top = newTop;
+        this.style.left = newLeft;
+    }
+
 };
 
 export {

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -10,10 +10,14 @@ class ButtonEditorView extends PartView {
         this.defaultWidth = "100px";
         this.defaultHeight = "100px";
 
+
+        // Configure the Shadow DOM and template
         this.template = document.createElement('template');
         this.template.innerHTML = templateString;
-        this._shadowRoot = this.attachShadow({mode: 'open'});
-        this._shadowRoot.appendChild(this.template.content.cloneNode(true));
+        this.shadow = this.attachShadow({mode: 'open'});
+        this.shadow.append(
+            this.template.content.cloneNode(true)
+        );
     }
 
     afterModelSet() {

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -76,7 +76,7 @@ const templateString = `
 </div>
 `;
 
-class ButtonEditorView extends PartView {
+class ButtonEditorView extends HTMLElement {
     constructor(){
         super();
 
@@ -91,50 +91,38 @@ class ButtonEditorView extends PartView {
         this.mouseDownInBar = false;
 
         // bind methods
-        this.setupPropHandlers = this.setupPropHandlers.bind(this);
+        this.setTarget = this.setTarget.bind(this);
         this.setupClickAndDrag = this.setupClickAndDrag.bind(this);
         this.setupField = this.setupField.bind(this);
         // this.setupBarButtons = this.setupBarButtons.bind(this);
         // this.setupExpanderAreas = this.setupExpanderAreas.bind(this);
-        this.onMouseMoveInBar = this.onMouseMoveInBar.bind(this);
         this.onMouseDownInBar = this.onMouseDownInBar.bind(this);
         this.onMouseUpAfterDrag = this.onMouseUpAfterDrag.bind(this);
-
-        // Setup prop change handlers
-        this.setupPropHandlers();
-    }
-
-    setupPropHandlers(){
-        this.onPropChange('targetId', (value) => {
-            this.setAttribute("target-id", value);
-        });
     }
 
 
-    afterModelSet() {
-        // set the editor field model
-
+    connectedCallback(){
+        if(this.isConnected){
+            this.setupClickAndDrag();
+            // this.setupBarButtons();
+            // this.setupExpanderAreas();
+            this.style.top = "50px";
+            this.style.left = "50px";
+        }
     }
 
-    afterConnected(){
-        this.setupClickAndDrag();
-        // this.setupBarButtons();
-        // this.setupExpanderAreas();
-        this.style.top = "50px";
-        this.style.left = "50px";
-        this.setupField();
+    disconnectedCallback(){
     }
 
-    afterDisconnected(){
+    setTarget(partId){
+        this.setAttribute("target-id", partId);
     }
 
     setupField(){
-        let partId = this.getAttribute("part-id");
-        let targetPart = window.System.partsById[partId];
-        let currentCardModel = window.System.getCurrentCardModel();
-        // create the field model and attach to current card
-        // of the new window.
-        let fieldModel = window.System.newModel('field', currentCardModel.id);
+        let targetId = this.getAttribute("target-id");
+        console.log(targetId);
+        let targetPart = window.System.partsById[targetId];
+        let fieldModel = window.System.newModel('field', this.model.id);
 
         // setup cusotm editor css classes
         let fieldView = window.System.findViewById(fieldModel.id);

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -1,7 +1,5 @@
 import ColorWheelWidget from '../drawing/ColorWheelWidget.js';
 
-const closeIcon = `<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-square-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M10 10l4 4m0 -4l-4 4"></path></svg>`;
-
 const templateString = `
 <style>
     :host {
@@ -124,7 +122,6 @@ position: absolute;
 </div>
 `;
 
-const SVGParser = new DOMParser();
 
 class ButtonEditorView extends HTMLElement {
     constructor(){
@@ -359,8 +356,6 @@ class ButtonEditorView extends HTMLElement {
         eventEl = document.createElement("div");
         let eventSpan = document.createElement("span");
         let closeSpan = document.createElement("span");
-        let xmlDocument = SVGParser.parseFromString(closeIcon, 'application/xml');
-        let closeSvgEl = xmlDocument.documentElement;
         closeSpan.name = eventName;
         eventEl.id = eventName;
         closeSpan.addEventListener('click', this.onIgnoreEvent);


### PR DESCRIPTION
### Main points ###

After some pain, a button editor. It does the basic things: 

Changes the name
Adjusts background and font colors (via our colorWheel)
Lists, adds, removes events
And lets you script

![image](https://user-images.githubusercontent.com/1154326/105910639-810d7300-6029-11eb-979c-7234445eefd1.png)

The editor is opened by pressing the "write/edit" icon, which previously opened the script/field editor. 

Instead of embedding all the widgets necessary to do editing (color, script) inside one editor view I decided that each would open it's own, absolutely positioned, widget. After some experimenting with both options, this was easier to style and scale, and in the end I prefer it overall. This way you can lay out the various sub-editor widgets as you see fit and we can just keep making more, adding  a button to open it to the main one:

![image](https://user-images.githubusercontent.com/1154326/105910948-ec574500-6029-11eb-838d-e16fcc9d2f42.png)

I tried to [stick to SimpleTalk](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-button-editor?expand=1#diff-d460e66340863153b40b711a201ef3dea6540293e5d5bc796755e4f238f0a473R241) in evoking the various sub-editors so that it would be clearer how one could build such a thing with just SimpleTalk buttons. You almost can do it at the moment... 

`editorOpen` is a now a [property](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-button-editor?expand=1#diff-d460e66340863153b40b711a201ef3dea6540293e5d5bc796755e4f238f0a473R241) on all parts. 

#### Tests ####

I wrote as many [tests](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-button-editor?expand=1#diff-0a1b715b2d04f9c839158dcb7132bfb2ba73b511ea8d03a2097b1851ac0dbe49) as I could think of, without dealing with npm canvas context issues (which you need to solve if you want to properly test our color wheels). They are reasonably comprehensive. 

#### Some issues ####
The fact that we couldn't write this in ST is a bit lame.. but I think we can get there. 
The css here is a mess. 
Adding and removing events causes this issue #97  (nothing to do with editor...)
The editor view is not really responsive. For example, it can send a `respond to [event]` message but it is not aware that the property changed to respond to that, so you have to [manually add it](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-button-editor?expand=1#diff-d460e66340863153b40b711a201ef3dea6540293e5d5bc796755e4f238f0a473R320). This is easy enough here, but we know in more complicated situations the fact that there is no responsiveness between the target model and it's editor. Potentially having the editor add itself to the target and then using the `target.onPropChange()` could work. But then we'd have `editor.target` and `target.editor` attributes floating around... or add a model for the editor. This is the reason I left a [basic version](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-button-editor?expand=1#diff-5c04e967413aec14e8cd22a4fe1f520620357e5acb7c9e24d4c5eb879fc22674) of that in (at first I had an editor model/view setup). TBD... 



Give it a go... 


