### PR TITLE
Daniel syntax debug

### DIFF
--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -5,6 +5,7 @@
  * SimpleTalk parts.
  */
 import idMaker from '../utils/idMaker.js';
+import errorHandler from '../utils/errorHandler.js';
 import eventMessenger from '../utils/eventMessenger.js';
 import {
     PartProperties,
@@ -46,6 +47,7 @@ class Part {
         this.setFuncHandler = this.setFuncHandler.bind(this);
         this.receiveCmd = this.receiveCmd.bind(this);
         this.receiveFunc = this.receiveFunc.bind(this);
+        this.receiveError = this.receiveError.bind(this);
         this.receiveMessage = this.receiveMessage.bind(this);
         this.delegateMessage = this.delegateMessage.bind(this);
         this.sendMessage = this.sendMessage.bind(this);
@@ -322,9 +324,15 @@ class Part {
             case 'function':
                 return this.receiveFunc(aMessage);
                 //break;
+            case 'error':
+                return this.receiveError(aMessage);
             default:
                 return this.delegateMessage(aMessage);
         }
+    }
+
+    receiveError(aMessage){
+        return errorHandler.handle(aMessage);
     }
 
     receiveCmd(aMessage){

--- a/js/objects/tests/test-error-handling-with-preload.js
+++ b/js/objects/tests/test-error-handling-with-preload.js
@@ -1,0 +1,55 @@
+/**
+ * Tests for Error Handling 
+ * -------------------------------------------
+ */
+import chai from 'chai';
+const assert = chai.assert;
+const expect = chai.expect;
+
+let currentCard;
+let button;
+describe('Error Handling', () => {
+    describe('Setup', () => {
+        it('Can add a new button to the current card', () => {
+            let makeButtonFunction = function(){
+                currentCard = System.getCurrentCardModel();
+                let msg = {
+                    type: 'command',
+                    commandName: 'newModel',
+                    args: ['button', currentCard.id]
+                };
+                currentCard.sendMessage(msg, currentCard);
+            };
+            expect(makeButtonFunction).to.not.throw();
+        });
+        it('Can find the button object, which has NO command handlers yet', () => {
+            button = System.getCurrentCardModel().subparts.find(subpart => {
+                return subpart.type == 'button';
+            });
+            assert.exists(button);
+            assert.isEmpty(button._commandHandlers);
+        });
+    });
+    describe('Compiling a bad script throws a corresponding "GrammarMatchError"', () => {
+        it('GrammarMatchError automatically opens the script editor (if not present)', () => {
+            let firstScript = [
+                'on doSomethingFirst',
+                'not a command',
+                'end doSomethingFirst',
+            ].join('\n');
+            button.partProperties.setPropertyNamed(button, "script", firstScript);
+            let scriptEditor = window.System.findScriptEditorByTargetId(button.id);
+            assert.isNotNull(scriptEditor);
+        });
+        it('Script editor has the propertly error marked content', () => {
+            let markedUpScript = [
+                'on doSomethingFirst',
+                'not a command <<<[Expected:"end"; ruleName: "StatementList"]',
+                'end doSomethingFirst',
+            ].join('\n');
+            let scriptEditor = window.System.findScriptEditorByTargetId(button.id);
+            let textContent = scriptEditor.model.partProperties.getPropertyNamed(scriptEditor, "textContent");
+            assert.equal(markedUpScript, textContent);
+        });
+    });
+});

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -1,0 +1,62 @@
+/**
+ * Error Handler
+ * ------------------------------------
+ * I am responsible for handler all
+ * System-wide errors
+ */
+
+const errorHandler = {
+
+    handle: function(aMessage){
+        switch(aMessage.name){
+            case 'GrammarMatchError':
+                return this.handleGrammarMatchError(aMessage);
+            default:
+                // if I don't know what to do with this message
+                // I send it along to the System
+                return window.System.sendMessage(aMessage);
+        }
+    },
+
+    handleGrammarMatchError: function(aMessage){
+        // first locate the script editor in question
+        let scriptEditor = window.System.findScriptEditorByTargetId(aMessage.partId);
+        if(!scriptEditor){
+            this._openScriptEditor(aMessage.partId);
+            scriptEditor = window.System.findScriptEditorByTargetId(aMessage.partId);
+        }
+        // TODO is there a more structured way to get this out of ohm?
+        let regex = /Line (?<line>\d), col (?<column>\d)/;
+        let match = aMessage.parsedScript.message.match(regex);
+        let errorLineNum = parseInt(match.groups["line"]) - 1; // ohm lines start with 1 
+        // see if the grammar rule has been identified
+        let ruleName;
+        let rightMostFailures = aMessage.parsedScript.getRightmostFailures();
+        if(rightMostFailures[1]){
+            ruleName = rightMostFailures[1].pexpr.ruleName;
+        }
+        // get some more info about what the parser expected
+        let expectedText = aMessage.parsedScript.getExpectedText();
+        let textContent = scriptEditor.model.partProperties.getPropertyNamed(scriptEditor, "textContent");
+        let textLines = textContent.split("\n");
+        // replace said text line with an error marker
+        textLines[errorLineNum] += ` <<<[Expected:${expectedText}; ruleName: "${ruleName}"]`;
+        textContent = textLines.join("\n");
+        scriptEditor.setTextValue(textContent);
+    },
+
+    _openScriptEditor: function(partId){
+        let targetView = window.System.findViewById(partId);
+        let msg = {
+            type: "command",
+            "commandName": "openScriptEditor",
+            args: [partId]
+        };
+        targetView.model.sendMessage(msg, targetView.model);
+    }
+};
+
+export {
+    errorHandler,
+    errorHandler as default
+};

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -14,7 +14,7 @@ const errorHandler = {
             default:
                 // if I don't know what to do with this message
                 // I send it along to the System
-                return window.System.sendMessage(aMessage);
+                return window.System.receiveMessage(aMessage);
         }
     },
 

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -40,7 +40,7 @@ const errorHandler = {
         let textContent = scriptEditor.model.partProperties.getPropertyNamed(scriptEditor, "textContent");
         let textLines = textContent.split("\n");
         // replace said text line with an error marker
-        textLines[errorLineNum] += ` <<<[Expected:${expectedText}; ruleName: "${ruleName}"]`;
+        textLines[errorLineNum] += ` --<<<[Expected:${expectedText}; ruleName: "${ruleName}"]`;
         textContent = textLines.join("\n");
         scriptEditor.setTextValue(textContent);
         // open the grammar

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -43,6 +43,8 @@ const errorHandler = {
         textLines[errorLineNum] += ` <<<[Expected:${expectedText}; ruleName: "${ruleName}"]`;
         textContent = textLines.join("\n");
         scriptEditor.setTextValue(textContent);
+        // open the grammar
+        this._openGrammar(aMessage.partId, ruleName);
     },
 
     _openScriptEditor: function(partId){
@@ -51,6 +53,16 @@ const errorHandler = {
             type: "command",
             "commandName": "openScriptEditor",
             args: [partId]
+        };
+        targetView.model.sendMessage(msg, targetView.model);
+    },
+
+    _openGrammar: function(partId, ruleName){
+        let targetView = window.System.findViewById(partId);
+        let msg = {
+            type: "command",
+            "commandName": "openSimpletalkGrammar",
+            args: [ruleName]
         };
         targetView.model.sendMessage(msg, targetView.model);
     }

--- a/js/objects/utils/eventMessenger.js
+++ b/js/objects/utils/eventMessenger.js
@@ -11,7 +11,7 @@ function eventMessenger(eventName, part){
         commandName: eventName,
         args: [],
         shouldIgnore: true
-    }
+    };
     part.sendMessage(message, part);
     return message;
 };

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -43,6 +43,7 @@ const templateString = `
     width: 100%;
     height: 90%;
     background-color: var(--palette-cornsik);
+    overflow: auto;
 }
 
 .field-textarea {
@@ -234,6 +235,7 @@ class FieldView extends PartView {
         this.onInput = this.onInput.bind(this);
         this.onClick = this.onClick.bind(this);
         this.textToHtml = this.textToHtml.bind(this);
+        this.setTextValue = this.setTextValue.bind(this);
         this.setupPropHandlers = this.setupPropHandlers.bind(this);
         this.setUpToolbar = this.setUpToolbar.bind(this);
         this._toolbarHandler = this._toolbarHandler.bind(this);
@@ -321,7 +323,7 @@ class FieldView extends PartView {
                 if(command === "fontsize"){
                     eventName = "change";
                 }
-                node.addEventListener(eventName, (event) => {this._toolbarHandler(event, command, value);})
+                node.addEventListener(eventName, (event) => {this._toolbarHandler(event, command, value);});
             }
         });
     }
@@ -350,13 +352,23 @@ class FieldView extends PartView {
         this.textarea.focus();
     }
 
+    setTextValue(text){
+        let innerHTML = this.textToHtml(text);
+        this.textarea.innerHTML = innerHTML;
+        this.model.partProperties.setPropertyNamed(
+            this.model,
+            'htmlContent',
+            innerHTML
+        );
+    }
+
     openColorWheelWidget(event, command){
         let colorWheelWidget = new ColorWheelWidget(command);
         // add an attribute describing the command
         colorWheelWidget.setAttribute("selector-command", command);
         // add a custom callback for the close button
         let closeButton = colorWheelWidget.shadowRoot.querySelector('#close-button');
-        closeButton.addEventListener('click', () => {colorWheelWidget.remove()});
+        closeButton.addEventListener('click', () => {colorWheelWidget.remove();});
         // add the colorWheelWidget
         event.target.parentNode.after(colorWheelWidget);
         // add a color-selected event callback


### PR DESCRIPTION
### Main Points ###

This PR introduces a prototype [error handler](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-syntax-debug?expand=1#diff-ad019d33cd101d6adeceb9553b2dfeeef98a8a808209c536107b05d948ff9ca2) 

The only types of errors it handles at the moment are `GrammarMatchError` and the rest it sends to System. But we like this setup it's clear how to add more cases. 

In the `GrammarMatchError` message there is now a [bit more](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-syntax-debug?expand=1#diff-27807be337857d016752d52609f4312048ef006984f0d2e108676823ffe892f6R318) data coming from Ohm, which is then used by the error handler to mark up the script. 

All it does is add a `<<<` marker at the end of the guilty line and some additional information (if Ohm provides it). Moreover, it also opens the grammar and scrolls to the corresponding rule line (if Ohm provided that). Like this: 

![image](https://user-images.githubusercontent.com/1154326/106181016-5ba17600-619d-11eb-8f51-a7c5aa0de8b1.png)

If the script editor is not open - for example if the script is set programmatically - the error handler will open it. 

### Tests ###
I wrote basic tests, but excluded testing for the presence of the Grammar field display (maybe we don't want this). 


### Issues ###
This does not handle runtime errors, such as  `DoesNotUnderstand` command, but if we like this I think handling that in a similar way will be good. This is also one reason I wanted to open the script editor if it's not present, i.e. have a system command handy for it. For example, if you press a button and a DNU message is throw, I imagine the error handler will open the button editor at the corresponding line. 

Is our grammar too lax.  For example:
```
on click
    what
end click
```
does not throw a parse error..  Yes we can handle it at runtime but maybe something so glaring should fail parsing. 