### PR TITLE
fixing various css issues

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -30,7 +30,7 @@
 /* Prerequisites */
 * {
     box-sizing: border-box;
-    z-index: 0;
+    flex-grow: 1;
 }
 
 .active {
@@ -54,7 +54,7 @@ st-world {
 st-stack {
     width: 100%;
     height: 100%;
-    position: relative;
+    display: flex;
 }
 
 st-world > st-stack {
@@ -124,6 +124,8 @@ st-button {
     font-family: monospace;
     border: 1px solid rgb(50, 50, 50);
     user-select: none;
+    margin-left: -1px;
+    margin-right: -1px;
 }
 
 st-button:not(.editing):hover {
@@ -161,14 +163,17 @@ st-window {
     box-shadow: 3px 4px 4px 0px rgba(50, 50, 50, 0.3);
 }
 
+st-window:active {
+    z-index: 100;
+}
 /* width and height of stacks in windows should
  * adjust based on contents, but at minimum be 100%
  * of parent
  */
 st-window > st-stack,
 st-window > st-stack > .current-card {
-    min-width: auto;
-    min-height: auto;
+    min-width: 100%;
+    min-height: 100%;
     height: auto;
     width: auto
 }
@@ -210,8 +215,11 @@ st-drawing {
 /* =Field Styles
  *----------------------------------------------------*/
 st-field {
-    width: 800px;
-    height: 300px;
+    min-height: 300px;
+}
+
+st-window st-field{
+    height: 100%;
 }
 
 /* =Editor Styles
@@ -226,6 +234,10 @@ st-button-editor{
 
 st-button-editor > color-wheel{
     position: absolute;
+}
+
+st-button-editor:active {
+    z-index: 100;
 }
 /* =Layout Class Styles
  * --------------------------------------------------------*/

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -41,7 +41,8 @@ const templateString = `
 
 .field-textarea-wrapper {
     width: 100%;
-    height: 90%;
+    height: 100%;
+    min-height: 300px;
     background-color: var(--palette-cornsik);
     overflow: auto;
 }

--- a/js/objects/views/WindowView.js
+++ b/js/objects/views/WindowView.js
@@ -242,11 +242,11 @@ class WindowView extends PartView {
             let box = view.getBoundingClientRect();
             let newWidth = Math.floor(box.width) + event.movementX;
             if(newWidth){
-                view.style.minWidth = `${newWidth}px`;
+                view.style.width = `${newWidth}px`;
             }
             let newHeight = Math.floor(box.height) + event.movementY;
             if(newHeight){
-                view.style.minHeight = `${newHeight}px`;
+                view.style.height = `${newHeight}px`;
             }
         }
     }


### PR DESCRIPTION
### Main points ###

Resizing on windows was broken. 

st-window -> st-stack -> st-card resizing was not working properly
allowing children of st-window.st-stack.st-card to grow and fit their parent
fixing various st-field related height and overflow issues
adding an active pseudo-class to boost z-index on selected elements


#### Notes ####

Our css is a little hacky, but this is a more global issues since we don't really know what we want.

Some things to consider:
* at the moment when we resize window we resize the [window-internal stack](https://github.com/UnitedLexCorp/SimpleTalk/blob/7e47e27a9e1158ffd9e286a9b9a722fe9b1c1691/js/objects/views/WindowView.js#L241) and then have the window parent adjust. Do we want to do this? or do we want to resize the window and have its children flex grow into it. 
* we should have a more natural window like interaction, i.e. when you click on a window it should remain the top (z-index) element until you click on something that it overlaps. i am not sure how to do this in pure css. We could do this at the card level but that would require a little design