### PR TITLE
Runtime errors

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -294,8 +294,13 @@ const System = {
         if(aMessage.shouldIgnore){
             return;
         }
-        console.error(aMessage);
-        throw new Error(`System does not understand message ${aMessage.type}`);
+        let originalSender = this.partsById[aMessage.senders[0].id];
+        let msg = {
+            type: "error",
+            name: "MessageNotUnderstood",
+            message: aMessage
+        };
+        originalSender.sendMessage(msg, originalSender);
     },
 
     compile: function(aMessage){
@@ -1420,7 +1425,11 @@ System._commandHandlers['openSimpletalkGrammar'] = function(senders, ruleName){
             let line = textArea.children[i];
             let text = line.textContent;
             if(text.match(regex)){
-                line.scrollIntoView();
+                try{
+                    line.scrollIntoView();
+                } catch (e) {
+                    console.log("script editor does not support line.scrollInfoView()");
+                };
             }
         };
     }

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -1435,6 +1435,57 @@ System._commandHandlers['openSimpletalkGrammar'] = function(senders, ruleName){
     }
 };
 
+System._commandHandlers['openDebugger'] = function(senders, partId){
+    let target = this.partsById[partId];
+    // The stack where the window will be inserted will
+    // be the current stack
+    let currentStackView = document.querySelector('.current-stack');
+    let insertStack = currentStackView.model;
+
+    let winModel = this.newModel('window', insertStack.id);
+    let winTitle = "Command Handlers";
+    winModel.partProperties.setPropertyNamed(
+        winModel,
+        'title',
+        winTitle
+    );
+    let winView = this.findViewById(winModel.id);
+    let winStackModel = this.newModel('stack', winModel.id);
+    let winStackView = this.findViewById(winStackModel.id);
+    winStackView.classList.add('window-stack');
+    let currentCardView = winView.querySelector('.current-stack .current-card');
+    let currentCard = currentCardView.model;
+
+    // Set the current card's layout to be a column list
+    currentCard.partProperties.setPropertyNamed(
+        currentCard,
+        'layout',
+        'list'
+    );
+
+    // Create the Field model and attach to current card
+    // of the new window.
+    let fieldModel = this.newModel('field', currentCard.id);
+    let fieldView = this.findViewById(fieldModel.id);
+
+    let textContent = "";
+    Object.keys(target.commandHandlerRegistry).forEach((name) =>{
+        let info = target.commandHandlerRegistry[name];
+        textContent += `${name}: ${JSON.stringify(info)}\n`;
+    });
+    let htmlContent = fieldView.textToHtml(textContent);
+    // set the inner html of the textarea with the proper htmlContent
+    // NOTE: at the moment fieldView does not subscribe to htmlContent
+    // change due to cursor focus and other issues
+    let textArea = fieldView._shadowRoot.querySelector(".field-textarea");
+    textArea.innerHTML = htmlContent;
+    fieldModel.partProperties.setPropertyNamed(
+        fieldModel,
+        'htmlContent',
+        htmlContent
+    );
+};
+
 System._commandHandlers['saveHTML'] = function(senders){
     let anchor = document.createElement('a');
     anchor.style.display = "none";

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -60,6 +60,7 @@ class Part {
         this.closeEditorCmdHandler = this.closeEditorCmdHandler.bind(this);
         this.isSubpartOfCurrentCard = this.isSubpartOfCurrentCard.bind(this);
         this.isSubpartOfCurrentStack = this.isSubpartOfCurrentStack.bind(this);
+        this.getOwnerBranch = this.getOwnerBranch.bind(this);
 
 
         // Finally, we finish initialization
@@ -82,6 +83,43 @@ class Part {
         return this.partProperties.setPropertyNamed(this, 'id', val);
     }
 
+
+    // Return an array of names of all of my and my ancestors' handlers
+    // for the moment this is just names, type, id and whether the handler overrides
+    // an owner's, but could be richer info, such as arguments, documentation etc
+    get commandHandlerRegistry(){
+        let handlersInfo = {};
+        let ownerBranch = this.getOwnerBranch();
+        for(let i = 1; i <= ownerBranch.length; i++){
+            let part = ownerBranch[ownerBranch.length - i];
+            let partType = part.type;
+            if(part.id === -1){
+                partType = "System";
+            }
+            Object.keys(part._commandHandlers).forEach((h) => {
+                let override = false;
+                if(handlersInfo[h]){
+                    override = true;
+                }
+                handlersInfo[h] = {partId: part.id, partType: partType, override: override};
+            });
+        }
+        return handlersInfo;
+    }
+
+    // returns the this.part -> System branch by part id
+    getOwnerBranch(branch){
+        if(!branch){
+            branch = [this];
+        }
+        if(this.type === "world"){
+            branch.push(window.System);
+            return branch;
+        } else {
+            branch.push(this._owner);
+        };
+        return this._owner.getOwnerBranch(branch);
+    }
     // perform a deep copy of myself (and all my suparts)
     // assigning new ids
     copy(ownerPart){

--- a/js/objects/tests/test-error-handling-with-preload.js
+++ b/js/objects/tests/test-error-handling-with-preload.js
@@ -30,7 +30,7 @@ describe('Error Handling', () => {
             assert.isEmpty(button._commandHandlers);
         });
     });
-    describe('Compiling a bad script throws a corresponding "GrammarMatchError"', () => {
+    describe('GrammarMatchError', () => {
         it('GrammarMatchError automatically opens the script editor (if not present)', () => {
             let firstScript = [
                 'on doSomethingFirst',
@@ -42,14 +42,39 @@ describe('Error Handling', () => {
             assert.isNotNull(scriptEditor);
         });
         it('Script editor has the propertly error marked content', () => {
-            let markedUpScript = [
+           let markedUpScript = [
                 'on doSomethingFirst',
-                'not a command <<<[Expected:"end"; ruleName: "StatementList"]',
+                'not a command --<<<[Expected:"end"; ruleName: "StatementList"]',
                 'end doSomethingFirst',
             ].join('\n');
             let scriptEditor = window.System.findScriptEditorByTargetId(button.id);
             let textContent = scriptEditor.model.partProperties.getPropertyNamed(scriptEditor, "textContent");
             assert.equal(markedUpScript, textContent);
+        });
+    });
+    describe('MessageNotUnderstood', () => {
+        before(() => {
+            // add a grammatically correct script that reference an unkown command
+            let firstScript = [
+                'on click',
+                'someNotACommandCommand',
+                'end click',
+            ].join('\n');
+            button.partProperties.setPropertyNamed(button, "script", firstScript);
+        });
+
+        it('Sending a MessageNotUnderstood', () => {
+            let MNUmsg = {
+                type: "error",
+                name: "MessageNotUnderstood",
+                message: {
+                    type: "command",
+                    commandName: "someNotACommandCommand",
+                    args: [],
+                    senders: [{name: "Button", id: button.id}]
+                }
+            };
+            button.sendMessage(MNUmsg, button);
         });
     });
 });

--- a/js/objects/tests/test-error-handling-with-preload.js
+++ b/js/objects/tests/test-error-handling-with-preload.js
@@ -87,7 +87,7 @@ describe('Error Handling', () => {
         it('MessageNotUnderstood command is marked up in the editor', () => {
             let markedUpScript = [
                 'on click',
-                'someNotACommandCommand --<<<[MessageNotUnderstood:command; commandName: "someNotACommandCommand"]',
+                'someNotACommandCommand --<<<[MessageNotUnderstood: command; commandName: "someNotACommandCommand"]',
                 'end click',
             ].join('\n');
             let scriptEditor = window.System.findScriptEditorByTargetId(anotherButton.id);

--- a/js/objects/tests/test-parts-with-preload.js
+++ b/js/objects/tests/test-parts-with-preload.js
@@ -1,0 +1,61 @@
+/**
+ * General Part Tests 
+ * -------------------------------------------
+ */
+import chai from 'chai';
+const assert = chai.assert;
+const expect = chai.expect;
+
+let currentCard;
+let button;
+describe('Basic functionality', () => {
+    describe('Setup', () => {
+        it('Can add a new button to the current card', () => {
+            let makeButtonFunction = function(){
+                currentCard = System.getCurrentCardModel();
+                let msg = {
+                    type: 'command',
+                    commandName: 'newModel',
+                    args: ['button', currentCard.id]
+                };
+                currentCard.sendMessage(msg, currentCard);
+            };
+            expect(makeButtonFunction).to.not.throw();
+        });
+        it('Can find the button object, which has NO command handlers yet', () => {
+            button = System.getCurrentCardModel().subparts.find(subpart => {
+                return subpart.type == 'button';
+            });
+            assert.exists(button);
+            assert.isEmpty(button._commandHandlers);
+        });
+    });
+    describe('Core methods"', () => {
+        it('Can get owner branch', () => {
+            let branch = button.getOwnerBranch();
+            let branchNodeByType = branch.map((node) => {return node.type;});
+            assert.deepEqual(branchNodeByType, ["button", "card", "stack", "world", undefined]);
+            assert.equal(branch[0].id, button.id);
+        });
+    });
+    describe('Command Handlers"', () => {
+        it('Can properly list all boot up command handlers present', () => {
+            // we just check for a few of the core handlers and make sure these
+            // are present, as these evolve too quickly to keep a comprehensive list
+            assert.deepEqual(button.commandHandlerRegistry["deleteModel"], {partId: -1, partType: "System", override: false});
+            assert.deepEqual(button.commandHandlerRegistry["newModel"], {partId: -1, partType: "System", override: false});
+            assert.deepEqual(button.commandHandlerRegistry["answer"], {partId: -1, partType: "System", override: false});
+            // since there are no new commands for the button, these should be the
+            // as for its parent card
+            assert.deepEqual(button.commandHandlerRegistry, button._owner.commandHandlerRegistry);
+        });
+        it('Adding a new command handler adds it to the registry', () => {
+            button._commandHandlers["newHandler"] = function(){};
+            assert.deepEqual(button.commandHandlerRegistry["newHandler"], {partId: button.id, partType: "button", override: false});
+        });
+        it('Overriding a command handler is properly registered', () => {
+            button._commandHandlers["answer"] = function(){};
+            assert.deepEqual(button.commandHandlerRegistry["answer"], {partId: button.id, partType: "button", override: true});
+        });
+    });
+});

--- a/js/objects/tests/test-system-script-editor-with-preload.js
+++ b/js/objects/tests/test-system-script-editor-with-preload.js
@@ -170,7 +170,7 @@ describe('ScriptEditor Functionality', () => {
             let fieldModel = editorFieldView.model;
             let textArea = editorFieldView._shadowRoot.querySelector('.field-textarea');
             let newHTMLContent = "on message ";
-            let completedHTMLContent = "on message <div>\t</div><div>end message<br></div>";
+            let completedHTMLContent = "on message <div><div>\t</div><div>end message</div><br></div>";
 
             // Simulate typing the input events
             let event = new window.Event('input');

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -64,14 +64,17 @@ const errorHandler = {
             let textContent = scriptEditor.model.partProperties.getPropertyNamed(scriptEditor, "textContent");
             let textLines = textContent.split("\n");
             // offending command text line with an error marker
-            textLines.forEach((line) => {
-                if(line.match(" ${commandName} ")){
-                    line += ` --<<<[MessageNotUnderstood:command; commandName: "${commandName}"]`;
+            let regex = new RegExp(`\\s*${commandName}(\s|$)`, 'g');
+            for(let i = 0; i < textLines.length; i++){
+                let line = textLines[i];
+                if(line.match(regex)){
+                    textLines[i] = line += ` --<<<[MessageNotUnderstood:command; commandName: "${commandName}"]`;
                 }
+            }
+            textLines.forEach((line) => {
             });
             textContent = textLines.join("\n");
             scriptEditor.setTextValue(textContent);
-            console.log(textContent);
         }
     },
 

--- a/js/objects/utils/errorHandler.js
+++ b/js/objects/utils/errorHandler.js
@@ -68,34 +68,53 @@ const errorHandler = {
             for(let i = 0; i < textLines.length; i++){
                 let line = textLines[i];
                 if(line.match(regex)){
-                    textLines[i] = line += ` --<<<[MessageNotUnderstood:command; commandName: "${commandName}"]`;
+                    textLines[i] = line += ` --<<<[MessageNotUnderstood: command; commandName: "${commandName}"]`;
                 }
             }
             textLines.forEach((line) => {
             });
             textContent = textLines.join("\n");
             scriptEditor.setTextValue(textContent);
+
+            // finally open the debugger (or current version thereof)
+            // NOTE: this is a bit dangerous, b/c if the System doesn't
+            // handle the `openDebugger` command anywhere it will throw
+            // a MNU error, which will then invoke this handler cuasing
+            // an infinite loop!
+            this._openDebugger(originalSender.id);
         }
     },
 
     _openScriptEditor: function(partId){
-        let targetView = window.System.findViewById(partId);
+        let target = window.System.partsById[partId];
         let msg = {
             type: "command",
             "commandName": "openScriptEditor",
             args: [partId]
         };
-        targetView.model.sendMessage(msg, targetView.model);
+        target.sendMessage(msg, target);
     },
 
     _openGrammar: function(partId, ruleName){
-        let targetView = window.System.findViewById(partId);
+        let target = window.System.partsById[partId];
         let msg = {
             type: "command",
             "commandName": "openSimpletalkGrammar",
             args: [ruleName]
         };
-        targetView.model.sendMessage(msg, targetView.model);
+        target.sendMessage(msg, target);
+    },
+
+    // At the moment this simply opens a st-window st-field with
+    // information about the available commands for said parts
+    _openDebugger: function(partId){
+        let target = window.System.partsById[partId];
+        let msg = {
+            type: "command",
+            "commandName": "openDebugger",
+            args: [partId]
+        };
+        target.sendMessage(msg, target);
     }
 };
 

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -414,7 +414,7 @@ class FieldView extends PartView {
         if(match){
             let messageName = match[1];
             // if input break is a new line then an extra
-            // <div></br></div> has beed added into the elemen alreadyt
+            // <div></br></div> has beed added into the elemen already
             let tabLine = "\t\n";
             if(match[2] === "\n"){
                 tabLine= "";
@@ -437,9 +437,17 @@ class FieldView extends PartView {
      */
     textToHtml(text){
         if(text){
-            if(text.includes("\n")){
-                text = "<div>" + text + "<br></div>";
-                return text.replace(/\n/g, "</div><div>");
+            let textLines = text.split("\n");
+            if(textLines.length > 1){
+                let html = "";
+                textLines.forEach((line) => {
+                    if(line){
+                        html += `<div>${line}</div>`;
+                    } else {
+                        html += "<div><br></div>";
+                    }
+                });
+                return  `<div>${html}<br></div>`;
             } else {
                 return text;
             }


### PR DESCRIPTION
### Main Points ###

This PR introduces runtime error handling, in particular the `MessageNotUnderstood` command type error as seen [here](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-runtime-errors?expand=1#diff-ad019d33cd101d6adeceb9553b2dfeeef98a8a808209c536107b05d948ff9ca2R52). With PR #99 we now have both grammar (scripting) and runtime error handling. In addition, it introduces the [command registry](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-runtime-errors?expand=1#diff-efd61be9944474fec7ba0b89d7a931fedae606964b569ff27b2766271c5244b9R90) which gathers information about commands available to the part and up the stack (keeping track of where the command is handled and whether it overrides one from above).  The registry addresses this issue #101 

A picture is best to explain all of this: 

![image](https://user-images.githubusercontent.com/1154326/107036605-31ae0c00-67ba-11eb-95d6-b5f4442c61d6.png)


In the script you see two things: overriding the System `answer` command and calling the `beep` command which does not exist and throws our MNU error. 

The script editor is marked up with the proper comment-message and a "debugger" is opened up. Currently our debugger is just the field with the command data displayed. It doesn't do any of the things I envision, but I named it "debugger" b/c that's what should open then and there. But you can see `answer` there (the highlight is just my mouse-select in the screenshot) and its `override: true` as expected, and you can see all the available commands, `openDebugger` for example is there. 

Tests have been written for everything above, except the debugger since I expect the current to be very temporary. 

I also [fixed](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-runtime-errors?expand=1#diff-48ed5cd662d43c127d7e1ce0f6f561e5d6a805cb07e182d40b4f3ddea2dbb1acR440) some lingering and annoying html display issues ... 