### PR TITLE
Scripted Drawing and Context Fixes

### DIFF
--- a/js/objects/ExecutionContext.js
+++ b/js/objects/ExecutionContext.js
@@ -10,11 +10,13 @@ class ExecutionContext {
     constructor(){
         this._lookup = {};
         this._current = null;
+        this._prev = null;
 
         // Bind methods
         this.get = this.get.bind(this);
         this.getLocal = this.getLocal.bind(this);
         this.setLocal = this.setLocal.bind(this);
+        this.restore = this.restore.bind(this);
     }
 
     // I retrieve the value corresponding to the variable name
@@ -43,11 +45,17 @@ class ExecutionContext {
                 _argVariableNames: []
             };
         }
+        this._prev = this._current;
         this._current = this._lookup[messageName];
     }
 
     get current(){
         return this._current;
+    }
+
+    restore(){
+        // Restore the previous context
+        this._current = this._prev;
     }
 };
 

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -90,7 +90,7 @@ class Button extends Part {
         this.partProperties.newBasicProp(
             'font-color',
             null
-        )
+        );
     }
 
     get type(){

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -55,11 +55,21 @@ class Drawing extends Part {
     }
 
     setupDrawingCommands(){
-        this._commandHandlers['lineTo'] = this.lineTo;
-        this._commandHandlers['moveTo'] = this.moveTo;
-        this._commandHandlers['beginDraw'] = this.beginDraw;
-        this._commandHandlers['endDraw'] = this.endDraw;
-        this._commandHandlers['stroke'] = this.stroke;
+        this.setPrivateCommandHandler('lineTo', (senders, ...args) => {
+            this.lineTo(...args);
+        });
+        this.setPrivateCommandHandler('moveTo', (senders, ...args) => {
+            this.moveTo(...args);
+        });
+        this.setPrivateCommandHandler('beginDraw', (senders, ...args) => {
+            this.beginDraw(...args);
+        });
+        this.setPrivateCommandHandler('finishDraw', (senders, ...args) => {
+            this.endDraw(...args);
+        });
+        this.setPrivateCommandHandler('stroke', (senders, ...args) => {
+            this.stroke(...args);
+        });
     }
 
     /* Scriptable Drawing Commands */
@@ -72,6 +82,7 @@ class Drawing extends Part {
         }
     }
     moveTo(coordPair){
+        console.log(this.activeContext, coordPair);
         if(this.isDrawing){
             let coords = this.coordsFromString(coordPair);
             this.activeContext.moveTo(

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -56,6 +56,7 @@ class Drawing extends Part {
 
     setupDrawingCommands(){
         this.setPrivateCommandHandler('lineTo', (senders, ...args) => {
+            console.log('is this working?');
             this.lineTo(...args);
         });
         this.setPrivateCommandHandler('moveTo', (senders, ...args) => {
@@ -81,23 +82,24 @@ class Drawing extends Part {
             this.activeContext.stroke();
         }
     }
-    moveTo(coordPair){
-        console.log(this.activeContext, coordPair);
+    moveTo(x, y){
+        console.log(`lineTo ${x}, ${y}`);
         if(this.isDrawing){
-            let coords = this.coordsFromString(coordPair);
+            //let coords = this.coordsFromString(coordPair);
             this.activeContext.moveTo(
-                coords.x,
-                coords.y
+                x,
+                y
             );
         }
     }
 
-    lineTo(coordPair){
+    lineTo(x, y){
+        console.log(`lineTo ${x}, ${y}`);
         if(this.isDrawing){
-            let coords = this.coordsFromString(coordPair);
+            //let coords = this.coordsFromString(coordPair);
             this.activeContext.lineTo(
-                coords.x,
-                coords.y
+                x,
+                y
             );
         }
     }

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -56,7 +56,6 @@ class Drawing extends Part {
 
     setupDrawingCommands(){
         this.setPrivateCommandHandler('lineTo', (senders, ...args) => {
-            console.log('is this working?');
             this.lineTo(...args);
         });
         this.setPrivateCommandHandler('moveTo', (senders, ...args) => {
@@ -83,7 +82,6 @@ class Drawing extends Part {
         }
     }
     moveTo(x, y){
-        console.log(`lineTo ${x}, ${y}`);
         if(this.isDrawing){
             //let coords = this.coordsFromString(coordPair);
             this.activeContext.moveTo(
@@ -94,7 +92,6 @@ class Drawing extends Part {
     }
 
     lineTo(x, y){
-        console.log(`lineTo ${x}, ${y}`);
         if(this.isDrawing){
             //let coords = this.coordsFromString(coordPair);
             this.activeContext.lineTo(

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -47,6 +47,7 @@ class Drawing extends Part {
         this.lineTo = this.lineTo.bind(this);
         this.beginDraw = this.beginDraw.bind(this);
         this.endDraw = this.endDraw.bind(this);
+        this.clear = this.clear.bind(this);
         this.coordsFromString = this.coordsFromString.bind(this);
     }
 
@@ -69,6 +70,9 @@ class Drawing extends Part {
         });
         this.setPrivateCommandHandler('stroke', (senders, ...args) => {
             this.stroke(...args);
+        });
+        this.setPrivateCommandHandler('clear', (senders, ...args) => {
+            this.clear(...args);
         });
     }
 
@@ -153,6 +157,30 @@ class Drawing extends Part {
             this.activeContext = null;
             this.isDrawing = false;
         }
+    }
+
+    clear(){
+        if(this.isDrawing){
+            return;
+        }
+        this.activeCanvas = document.createElement('canvas');
+        this.activeCanvas.width = this.partProperties.getPropertyNamed(
+            this,
+            'width'
+        );
+        this.activeCanvas.height = this.partProperties.getPropertyNamed(
+            this,
+            'height'
+        );
+        this.activeContext = this.activeCanvas.getContext('2d');
+        this.partProperties.setPropertyNamed(
+            this,
+            'image',
+            this.activeCanvas.toDataURL()
+        );
+        this.activeCanvas = null;
+        this.activeContext = null;
+        
     }
 
     /* Utility Methods for Scriptable Drawing */

--- a/js/objects/views/drawing/DrawingView.js
+++ b/js/objects/views/drawing/DrawingView.js
@@ -79,6 +79,13 @@ class DrawingView extends PartView {
 
     setupPropHandlers(){
         this.onPropChange('mode', this.modeChanged);
+        this.onPropChange('image', () => {
+            let imageBits = this.model.partProperties.getPropertyNamed(
+                this.model,
+                'image'
+            );
+            this.restoreImageFromModel(imageBits);
+        });
     }
 
     modeChanged(value){

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -60,6 +60,9 @@ const createInterpreterSemantics = (partContext, systemContext) => {
                         let message = statementLine.interpret();
                     });
                 });
+
+                // Restore any previous execution context
+                partContext._executionContext.restore();
             };
             
             partContext._commandHandlers[messageName] = handlerFunction;


### PR DESCRIPTION
## What
This PR does two things:
1. Gives us the ability to execute basic drawing commands on the Drawing part via scripting/built-in command handlers;
2. Fixes an important issue regarding ExecutionContext, where old contexts were not being restored and variables were being overwritten.

## ExecutionContext ##
See the explanation in [this commit](https://github.com/UnitedLexCorp/SimpleTalk/commit/cd15af59d135e22af1f17a7854028d236859f918)
  
## Drawing Commands ##
We currently support the following commands: `beginDraw`, `finishDraw`, `lineTo`, `moveTo`, `stroke`. See the example script below.
  
What other drawing operations should we support? Should values like line width, color, fillstyle, etc be set as properties on the model, or should they be set via commands? The latter would work, since the model activates its own canvas context after `beginDraw` is executed.
  
Note also that for now the draw operations on the view side are not linked to these model side commands -- this is an optimization that (I believe) permits smoother mouse painting.
  
## Example ##
Here is an example script that works:
```simpletalk
on myDrawing
	put 50 into startX
	put 50 into startY
	put 200 into currentSize
	put 5 into increment
	beginDraw
	repeat until currentSize < 10
		drawSquare startX, startY, currentSize
		put (currentSize - (increment * 4)) into currentSize
		put (startX + increment) into startX
		put (startY + increment) into startY
	end repeat
	finishDraw
end myDrawing


on drawSquare x, y, size
	moveTo x, y
	lineTo (x + size), y
	lineTo (x + size), (y + size)
	lineTo x, (y + size)
	lineTo x, y
	stroke
end drawSquare
```
  
And produces: 
![Screenshot from 2021-02-11 13-50-13](https://user-images.githubusercontent.com/1640299/107686020-b0032600-6c72-11eb-9f3c-de8bec9098ea.png)
