### PR TITLE
css refactoring

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -24,7 +24,7 @@
     --drawing-default-width: 500px;
     --drawing-default-height: 300px;
     --field-default-width: 40vw;
-    --field-default-height: 20vh;
+    --field-default-height: 30vh;
 }
 
 /* Keyframe Animations */
@@ -39,8 +39,7 @@
 }
 
 .active {
-    background-color: black;
-    color: white;
+    outline: solid var(--palette-orange) 1px;
 }
 
 /* =World Styles
@@ -97,6 +96,10 @@ st-button:not(.editing):hover {
     cursor: pointer;
 }
 
+st-button:(.editing){
+    background-color: white;
+    color: black;
+}
 /* =Window Styles
  *----------------------------------------------------*/
 st-window {
@@ -145,6 +148,7 @@ st-svg {
  *----------------------------------------------------*/
 st-drawing {
     background-color: #1fe0; /* transparent */
+    position: absolute;
 }
 
 /* =Field Styles
@@ -152,6 +156,7 @@ st-drawing {
 st-field {
     width: var(--field-default-width);
     height: var(--field-default-height);
+    position: absolute;
 }
 
 

--- a/css/core.css
+++ b/css/core.css
@@ -19,6 +19,12 @@
     --palette-orange: #ff7c5d;
     --palette-red: #c70151;
     --palette-cornsik: #FFF8DC;
+    --container-default-width: 20vw;
+    --container-default-height: 15vh;
+    --drawing-default-width: 500px;
+    --drawing-default-height: 300px;
+    --field-default-width: 30vw;
+    --field-default-height: 20vh;
 }
 
 /* Keyframe Animations */
@@ -29,8 +35,7 @@
 
 /* Prerequisites */
 * {
-    box-sizing: border-box;
-    flex-grow: 1;
+    visibility: initial;
 }
 
 .active {
@@ -41,55 +46,14 @@
 /* =World Styles
  *----------------------------------------------------*/
 st-world {
-    display: block;
-    position: relative;
-    width: 100%;
-    height: 100%;
-    background-color: pink;
+    visibility: hidden;
 }
 
 
 /* =Stack Styles
  *----------------------------------------------------*/
 st-stack {
-    width: 100%;
-    height: 100%;
-    display: flex;
-}
-
-st-world > st-stack {
-     display: none;
-}
-
-.current-stack {
-    display: block;
-}
-
-.current-stack > st-window {
-    z-index: 1;
-}
-
-.current-stack > st-button {
-    z-index: 1;
-}
-
-.current-stack > st-container {
-    z-index: 1;
-}
-/* =Background Styles
- *----------------------------------------------------*/
-st-background {
-    display: block;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-}
-
-/* Give a pinkish background color to the background
- * of the current Stack in the world (but not Windows, etc)
- */
-st-world > .current-stack > st-background {
-    background-color: var(--palette-blue);
+    visibility: hidden;
 }
 
 
@@ -104,6 +68,7 @@ st-card {
 
 .current-card {
     display: block;
+    visibility: initial;
     background-color: var(--palette-blue);
 }
 
@@ -132,25 +97,6 @@ st-button:not(.editing):hover {
     cursor: pointer;
 }
 
-
-/* =Layout Styles
- *----------------------------------------------------*/
-st-layout {
-    display: flex;
-    position: absolute;
-    border: 1px solid transparent;
-    box-sizing: border-box;
-}
-
-st-layout.list-column {
-    flex-direction: column;
-}
-
-st-layout.list-row {
-    flex-direction: row;
-}
-
-
 /* =Window Styles
  *----------------------------------------------------*/
 st-window {
@@ -166,37 +112,26 @@ st-window {
 st-window:active {
     z-index: 100;
 }
-/* width and height of stacks in windows should
- * adjust based on contents, but at minimum be 100%
- * of parent
- */
-st-window > st-stack,
-st-window > st-stack > .current-card {
-    min-width: 100%;
-    min-height: 100%;
-    height: auto;
-    width: auto
-}
 
-/* This is the fix for Toolbox window's
- * layout, but it's hacky and suggests that
- * perhaps layouts should be more fundamental
- **/
-st-window > st-stack > .current-card > st-layout {
-    position: relative;
-}
-
+ *---------------------------------------
 /* =Container Styles
  *---------------------------------------------------------*/
 st-container {
     position: absolute;
     border: 1px solid rgb(150, 150, 150);
+    width: var(--container-default-width);
+    height: var(--container-default-height);
 }
 
 st-container:empty {
-    min-height: 100px;
-    min-width: 100px;
+    display: block;
+    position: absolute;
+    border: 1px solid rgb(150, 150, 150);
+    width: var(--container-default-width);
+    height: var(--container-default-height);
 }
+-----------------*/
+
 
 /* =Svg Styles
  *---------------------------------------------------------*/
@@ -210,17 +145,17 @@ st-svg {
  *----------------------------------------------------*/
 st-drawing {
     background-color: #1fe0; /* transparent */
+    width: var(--drawing-default-width);
+    height: var(--drawing-default-height);
 }
 
 /* =Field Styles
  *----------------------------------------------------*/
 st-field {
-    min-height: 300px;
+    width: var(--field-default-width);
+    height: var(--field-default-height);
 }
 
-st-window st-field{
-    height: 100%;
-}
 
 /* =Editor Styles
  *----------------------------------------------------*/
@@ -239,6 +174,7 @@ st-button-editor > color-wheel{
 st-button-editor:active {
     z-index: 100;
 }
+
 /* =Layout Class Styles
  * --------------------------------------------------------*/
 .list-layout {

--- a/css/core.css
+++ b/css/core.css
@@ -23,7 +23,7 @@
     --container-default-height: 15vh;
     --drawing-default-width: 500px;
     --drawing-default-height: 300px;
-    --field-default-width: 30vw;
+    --field-default-width: 40vw;
     --field-default-height: 20vh;
 }
 
@@ -145,8 +145,6 @@ st-svg {
  *----------------------------------------------------*/
 st-drawing {
     background-color: #1fe0; /* transparent */
-    width: var(--drawing-default-width);
-    height: var(--drawing-default-height);
 }
 
 /* =Field Styles

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -73,11 +73,11 @@ class Button extends Part {
             true,
         );
         // TODO tbd props
-        this.partProperties.newStyleProp(
+        this.partProperties.newBasicProp(
             'autoHilite',
             true
         );
-        this.partProperties.newStyleProp(
+        this.partProperties.newBasicProp(
             'draggable',
             true
         );

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -91,6 +91,10 @@ class Button extends Part {
             'left',
             "0",
         );
+        this.partProperties.newStyleProp(
+            'rotate',
+            null,
+        );
         // TODO tbd props
         this.partProperties.newBasicProp(
             'autoHilite',

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -44,20 +44,28 @@ class Button extends Part {
         );
 
         this.partProperties.newBasicProp(
-            'style',
-            'normal'
-        );
-        this.partProperties.newBasicProp(
-            'textAlign',
+            'text-align',
             'center'
         );
         this.partProperties.newBasicProp(
-            'textFont',
+            'text-font',
             'default'
         );
         this.partProperties.newBasicProp(
-            'textStyle',
+            'background-color',
+            null
+        );
+        this.partProperties.newBasicProp(
+            'text-color',
+            null
+        );
+        this.partProperties.newBasicProp(
+            'text-style',
             'plain'
+        );
+        this.partProperties.newBasicProp(
+            'name-visible',
+            true
         );
         this.partProperties.newBasicProp(
             'visible',
@@ -68,29 +76,9 @@ class Button extends Part {
             true
         );
         this.partProperties.newBasicProp(
-            'hilite',
-            false
-        );
-        this.partProperties.newBasicProp(
-            'iconAlign',
-            'center'
-        );
-        this.partProperties.newBasicProp(
-            'showName',
-            true
-        );
-        this.partProperties.newBasicProp(
             'draggable',
             true
         );
-        this.partProperties.newBasicProp(
-            'background-color',
-            null
-        );
-        this.partProperties.newBasicProp(
-            'font-color',
-            null
-        )
     }
 
     get type(){

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -43,42 +43,45 @@ class Button extends Part {
             [] // no aliases
         );
 
-        this.partProperties.newBasicProp(
+        // Styling
+        this.partProperties.newStyleProp(
             'text-align',
-            'center'
+            'center',
         );
-        this.partProperties.newBasicProp(
+        this.partProperties.newStyleProp(
             'text-font',
-            'default'
+            'default',
         );
-        this.partProperties.newBasicProp(
+        this.partProperties.newStyleProp(
             'background-color',
-            null
+            null,
         );
-        this.partProperties.newBasicProp(
+        this.partProperties.newStyleProp(
             'text-color',
-            null
+            null,
         );
-        this.partProperties.newBasicProp(
+        this.partProperties.newStyleProp(
             'text-style',
-            'plain'
+            'plain',
         );
-        this.partProperties.newBasicProp(
+        this.partProperties.newStyleProp(
             'name-visible',
-            true
+            true,
         );
-        this.partProperties.newBasicProp(
+        this.partProperties.newStyleProp(
             'visible',
-            true
+            true,
         );
-        this.partProperties.newBasicProp(
+        // TODO tbd props
+        this.partProperties.newStyleProp(
             'autoHilite',
             true
         );
-        this.partProperties.newBasicProp(
+        this.partProperties.newStyleProp(
             'draggable',
             true
         );
+        this.setupStyleProperties();
     }
 
     get type(){

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -83,6 +83,14 @@ class Button extends Part {
             'height',
             null,
         );
+        this.partProperties.newStyleProp(
+            'top',
+            "0",
+        );
+        this.partProperties.newStyleProp(
+            'left',
+            "0",
+        );
         // TODO tbd props
         this.partProperties.newBasicProp(
             'autoHilite',

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -72,6 +72,17 @@ class Button extends Part {
             'visible',
             true,
         );
+        // setting width and height to null
+        // effectively forces to the default size
+        // of the button to fit the button name
+        this.partProperties.newStyleProp(
+            'width',
+            null,
+        );
+        this.partProperties.newStyleProp(
+            'height',
+            null,
+        );
         // TODO tbd props
         this.partProperties.newBasicProp(
             'autoHilite',

--- a/js/objects/parts/Card.js
+++ b/js/objects/parts/Card.js
@@ -61,6 +61,13 @@ class Card extends Part {
             new Set(['click', 'dragenter', 'dragover', 'drop'])
         );
 
+        // Styling
+        this.partProperties.newStyleProp(
+            'background-color',
+            null,
+        );
+
+        this.setupStyleProperties();
 
         // Cards have the layout set
         // of properties, so we add

--- a/js/objects/parts/Container.js
+++ b/js/objects/parts/Container.js
@@ -36,7 +36,14 @@ class Container extends Part {
             'height',
             "200px",
         );
-
+        this.partProperties.newStyleProp(
+            'top',
+            "0",
+        );
+        this.partProperties.newStyleProp(
+            'left',
+            "0",
+        );
         this.setupStyleProperties();
     }
 

--- a/js/objects/parts/Container.js
+++ b/js/objects/parts/Container.js
@@ -44,6 +44,10 @@ class Container extends Part {
             'left',
             "0",
         );
+        this.partProperties.newStuyleProp(
+            'rotate',
+            null
+        );
         this.setupStyleProperties();
     }
 

--- a/js/objects/parts/Container.js
+++ b/js/objects/parts/Container.js
@@ -28,6 +28,14 @@ class Container extends Part {
             'background-color',
             null,
         );
+        this.partProperties.newStyleProp(
+            'width',
+            "300px",
+        );
+        this.partProperties.newStyleProp(
+            'height',
+            "200px",
+        );
 
         this.setupStyleProperties();
     }

--- a/js/objects/parts/Container.js
+++ b/js/objects/parts/Container.js
@@ -22,6 +22,14 @@ class Container extends Part {
 
         // accept all subparts
         this.acceptedSubpartTypes = ["*"];
+
+        // Styling
+        this.partProperties.newStyleProp(
+            'background-color',
+            null,
+        );
+
+        this.setupStyleProperties();
     }
 
     get type(){

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -26,6 +26,10 @@ class Drawing extends Part {
             'left',
             "0",
         );
+        this.partProperties.newStyleProp(
+            'rotate',
+            null
+        );
         this.setupStyleProperties();
 
         // When drawing from a script/commands,

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -18,17 +18,17 @@ class Drawing extends Part {
             'drawing'
         );
 
-        // Adjust any properties as needed
-        this.partProperties.setPropertyNamed(
-            this,
-            'width',
-            250
-        );
-        this.partProperties.setPropertyNamed(
-            this,
+        // Styling
+        this.partProperties.newStyleProp(
             'height',
             250
         );
+        this.partProperties.newStyleProp(
+            'width',
+            250
+        );
+
+        this.setupStyleProperties();
 
         // When drawing from a script/commands,
         // we will use this as the open canvas

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -17,6 +17,16 @@ class Drawing extends Part {
             'mode',
             'drawing'
         );
+        // Style
+        this.partProperties.newStyleProp(
+            'top',
+            "0",
+        );
+        this.partProperties.newStyleProp(
+            'left',
+            "0",
+        );
+        this.setupStyleProperties();
 
         // When drawing from a script/commands,
         // we will use this as the open canvas

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -18,18 +18,6 @@ class Drawing extends Part {
             'drawing'
         );
 
-        // Styling
-        this.partProperties.newStyleProp(
-            'height',
-            250
-        );
-        this.partProperties.newStyleProp(
-            'width',
-            250
-        );
-
-        this.setupStyleProperties();
-
         // When drawing from a script/commands,
         // we will use this as the open canvas
         // whose image bytes will be set to the

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -77,6 +77,19 @@ class Field extends Part {
             'wideMargins',
             false
         );
+        // Styling
+        // setting width and height to null
+        // effectively forces to the default size
+        // of the button to fit the button name
+        this.partProperties.newStyleProp(
+            'width',
+            null,
+        );
+        this.partProperties.newStyleProp(
+            'height',
+            null,
+        );
+        this.setupStyleProperties();
     }
 
     get type(){

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -97,6 +97,10 @@ class Field extends Part {
             'left',
             "0",
         );
+        this.partProperties.newStyleProp(
+            'rotate',
+            null
+        );
         this.setupStyleProperties();
     }
 

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -89,6 +89,14 @@ class Field extends Part {
             'height',
             null,
         );
+        this.partProperties.newStyleProp(
+            'top',
+            "0",
+        );
+        this.partProperties.newStyleProp(
+            'left',
+            "0",
+        );
         this.setupStyleProperties();
     }
 

--- a/js/objects/parts/Image.js
+++ b/js/objects/parts/Image.js
@@ -41,6 +41,15 @@ class Image extends Part {
             'draggable',
             false
         );
+        this.partProperties.newStyleProp(
+            'top',
+            "0",
+        );
+        this.partProperties.newStyleProp(
+            'left',
+            "0",
+        );
+        this.setupStyleProperties();
 
         // Private command handlers
         this.setPrivateCommandHandler("loadImageFrom", this.loadImageFromSource);

--- a/js/objects/parts/Image.js
+++ b/js/objects/parts/Image.js
@@ -49,6 +49,10 @@ class Image extends Part {
             'left',
             "0",
         );
+        this.partProperties.newStyleProp(
+            'rotate',
+            null
+        );
         this.setupStyleProperties();
 
         // Private command handlers

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -184,10 +184,6 @@ class Part {
                 true
             ),
             new BasicProperty(
-                'height',
-                0
-            ),
-            new BasicProperty(
                 'id',
                 idMaker.new()
             ),
@@ -226,14 +222,6 @@ class Part {
             new BasicProperty(
                 'topLeft',
                 0
-            ),
-            new BasicProperty(
-                'width',
-                0
-            ),
-            new BasicProperty(
-                'backgroundColor',
-                'white'
             ),
             new BasicProperty(
                 'editorOpen',

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -168,14 +168,6 @@ class Part {
         // to ALL Parts in the system.
         let basicProps = [
             new BasicProperty(
-                'bottom',
-                0
-            ),
-            new BasicProperty(
-                'bottomRight',
-                0
-            ),
-            new BasicProperty(
                 'contents',
                 null,
             ),
@@ -188,16 +180,6 @@ class Part {
                 idMaker.new()
             ),
             new BasicProperty(
-                'left',
-                0
-            ),
-            new BasicProperty(
-                'location',
-                0,
-                false,
-                ['loc']
-            ),
-            new BasicProperty(
                 'name',
                 ''
             ),
@@ -208,20 +190,8 @@ class Part {
                 ['rect']
             ),
             new BasicProperty(
-                'right',
-                0
-            ),
-            new BasicProperty(
                 'script',
                 null // For now
-            ),
-            new BasicProperty(
-                'top',
-                0
-            ),
-            new BasicProperty(
-                'topLeft',
-                0
             ),
             new BasicProperty(
                 'editorOpen',

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -244,6 +244,13 @@ class Part {
                 new Set(),
                 false,
                 []
+            ),
+            // Styling
+            // css (really JS style) key-values
+            new BasicProperty(
+                'cssStyle',
+                {},
+                false,
             )
         ];
         basicProps.forEach(prop => {

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -39,6 +39,7 @@ class Part {
         // Bind methods
         this.copy = this.copy.bind(this);
         this.setupProperties = this.setupProperties.bind(this);
+        this.setupStyleProperties = this.setupStyleProperties.bind(this);
 
         this.addPart = this.addPart.bind(this);
         this.removePart = this.removePart.bind(this);
@@ -291,6 +292,19 @@ class Part {
             },
             function(){return} // no getter
         );
+    }
+
+    // To be called in each sub-class that has StyleProperties
+    // called after the style props are configured
+    setupStyleProperties(){
+        this.partProperties._properties.forEach((prop) => {
+            if(prop.constructor.name === "StyleProperty"){
+                // setting the value on itself ensures that the cssStyle
+                // BasicProperty is updated with the appropriate styler
+                // conversion css key-val
+                prop.setValue(this, prop._value);
+            }
+        });
     }
 
     /** Subpart Access **/

--- a/js/objects/parts/Window.js
+++ b/js/objects/parts/Window.js
@@ -55,6 +55,10 @@ class Window extends Part {
             'left',
             "0",
         );
+        this.partProperties.newStyleProp(
+            'rotate',
+            null
+        );
         this.setupStyleProperties();
 
         // Bind methods

--- a/js/objects/parts/Window.js
+++ b/js/objects/parts/Window.js
@@ -46,6 +46,16 @@ class Window extends Part {
             'isResizable',
             true
         );
+        // Style
+        this.partProperties.newStyleProp(
+            'top',
+            "0",
+        );
+        this.partProperties.newStyleProp(
+            'left',
+            "0",
+        );
+        this.setupStyleProperties();
 
         // Bind methods
         this.setTarget = this.setTarget.bind(this);

--- a/js/objects/properties/LayoutProperties.js
+++ b/js/objects/properties/LayoutProperties.js
@@ -5,14 +5,14 @@
  * that will supply them with the needed Part
  * Properties relevant to Layouts.
  */
-const addLayoutProperties = (aPart) => {
+const addLayoutProperties = (aPart, kind='absolute') => {
     // The kind of layout. For now
-    // only 'list' and null are possible.
-    // null is the normal, absolute position
+    // only 'absolute' and 'list' are possible.
+    // absolute is the default position
     // layout. It is also the default
     aPart.partProperties.newBasicProp(
         'layout',
-        null
+        kind
     );
 
     // If the layout is 'list', this
@@ -31,6 +31,7 @@ const addLayoutProperties = (aPart) => {
         'listItemSpacing',
         null
     );
+
 };
 
 export {

--- a/js/objects/properties/PartProperties.js
+++ b/js/objects/properties/PartProperties.js
@@ -1,3 +1,5 @@
+import cssStyler from '../utils//styler.js';
+
 /**
  * PartProperties
  * ------------------------------------
@@ -107,6 +109,29 @@ class DynamicProperty extends BasicProperty {
                     val
                 );
             }
+        }
+    }
+};
+
+
+/** I am a special property which handles interfacing with the
+  * the cssStyle basic property. Whenever I am updated I make
+  * sure to update the cssStyle property via the styler utility
+  * function. I can be used to create different and indepent
+  * styling options.
+  **/
+class StyleProperty extends BasicProperty {
+    constructor(name, styler=cssStyler, readOnly=false, aliases=[]){
+        super(name, null, readOnly, aliases);
+    }
+
+    // In this override, we update the cssStyle property
+    setValue(owner, val, notify=true){
+        if(!this.readOnly){
+            let styleProperty = owner.partProperties.findPropertyNamed("cssStyle");
+            let style = styleProperty.getValue(owner);
+            newStyle = styler(style);
+            styleProperty.setValue(owner, newStyle, notify);
         }
     }
 };

--- a/js/objects/properties/PartProperties.js
+++ b/js/objects/properties/PartProperties.js
@@ -121,8 +121,9 @@ class DynamicProperty extends BasicProperty {
   * styling options.
   **/
 class StyleProperty extends BasicProperty {
-    constructor(name, styler=cssStyler, readOnly=false, aliases=[]){
-        super(name, null, readOnly, aliases);
+    constructor(name, defaultValue,  styler=cssStyler, readOnly=false, aliases=[]){
+        super(name, defaultValue, readOnly, aliases);
+        this.styler = styler;
     }
 
     // In this override, we update the cssStyle property
@@ -130,7 +131,7 @@ class StyleProperty extends BasicProperty {
         if(!this.readOnly){
             let styleProperty = owner.partProperties.findPropertyNamed("cssStyle");
             let style = styleProperty.getValue(owner);
-            newStyle = styler(style);
+            let newStyle = this.styler(style, this.name, val);
             styleProperty.setValue(owner, newStyle, notify);
         }
     }
@@ -148,6 +149,7 @@ class PartProperties {
         this.setPropertyNamed = this.setPropertyNamed.bind(this);
         this.getPropertyNamed = this.getPropertyNamed.bind(this);
         this.newBasicProp = this.newBasicProp.bind(this);
+        this.newStyleProp = this.newStyleProp.bind(this);
         this.newDynamicProp = this.newDynamicProp.bind(this);
         this._indexOfProperty = this._indexOfProperty.bind(this);
     }
@@ -231,6 +233,13 @@ class PartProperties {
     // property.
     newBasicProp(...args){
         let newProp = new BasicProperty(...args);
+        this.addProperty(newProp);
+    }
+
+    // Convenience method for creating a new style 
+    // property.
+    newStyleProp(...args){
+        let newProp = new StyleProperty(...args);
         this.addProperty(newProp);
     }
 

--- a/js/objects/tests/test-editors-with-preload.js
+++ b/js/objects/tests/test-editors-with-preload.js
@@ -98,7 +98,7 @@ describe('Button Editor tests', () => {
             let editorView = document.querySelector('st-button-editor');
             let buttonBG = editorView._shadowRoot.querySelector('button.background-color');
             assert.isNotNull(buttonBG);
-            let buttonFont = editorView._shadowRoot.querySelector('button.font-color');
+            let buttonFont = editorView._shadowRoot.querySelector('button.text-color');
             assert.isNotNull(buttonFont);
         });
         it('All default button events are present', () => {

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -24,7 +24,7 @@ describe('CSS Styler Util', () => {
     });
     it('Name visibility', () => {
         cssStyler(stylerObj, "name-visible", true);
-        assert.equal(stylerObj["color"], "red");
+        assert.equal(stylerObj["color"], "initial");
         cssStyler(stylerObj, "name-visible", false);
         assert.equal(stylerObj["color"], "transparent");
     });
@@ -37,6 +37,16 @@ describe('CSS Styler Util', () => {
     it('Background Color style conversion', () => {
         cssStyler(stylerObj, "background-color", "red");
         assert.equal(stylerObj["backgroundColor"], "red");
+    });
+    it('Unit properties (top, left) conversion', () => {
+        cssStyler(stylerObj, "top", 2);
+        assert.equal(stylerObj["top"], "2px");
+        cssStyler(stylerObj, "top", "2");
+        assert.equal(stylerObj["top"], "2px");
+        cssStyler(stylerObj, "top", "2px");
+        assert.equal(stylerObj["top"], "2px");
+        cssStyler(stylerObj, "top", null);
+        assert.equal(stylerObj["top"], "2px");
     });
     it('Null or undefined value styles do not update the style object', () => {
         cssStyler(stylerObj, "background-color", null);

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -38,7 +38,7 @@ describe('CSS Styler Util', () => {
         cssStyler(stylerObj, "background-color", "red");
         assert.equal(stylerObj["backgroundColor"], "red");
     });
-    it('Unit properties (top, left) conversion', () => {
+    it('Unit px properties (top, left) conversion', () => {
         cssStyler(stylerObj, "top", 2);
         assert.equal(stylerObj["top"], "2px");
         cssStyler(stylerObj, "top", "2");
@@ -47,6 +47,14 @@ describe('CSS Styler Util', () => {
         assert.equal(stylerObj["top"], "2px");
         cssStyler(stylerObj, "top", null);
         assert.equal(stylerObj["top"], "2px");
+    });
+    it('Unit rotate(deg) property conversion', () => {
+        cssStyler(stylerObj, "rotate", null);
+        assert.equal(stylerObj["transform"], undefined);
+        cssStyler(stylerObj, "rotate", 20);
+        assert.equal(stylerObj["transform"], "rotate(20deg)");
+        cssStyler(stylerObj, "rotate", -20);
+        assert.equal(stylerObj["transform"], "rotate(-20deg)");
     });
     it('Null or undefined value styles do not update the style object', () => {
         cssStyler(stylerObj, "background-color", null);

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -38,6 +38,12 @@ describe('CSS Styler Util', () => {
         cssStyler(stylerObj, "background-color", "red");
         assert.equal(stylerObj["backgroundColor"], "red");
     });
+    it('Null or undefined value styles do not update the style object', () => {
+        cssStyler(stylerObj, "background-color", null);
+        assert.equal(stylerObj["backgroundColor"], "red");
+        cssStyler(stylerObj, "background-color", undefined);
+        assert.equal(stylerObj["backgroundColor"], "red");
+    });
     it('Styles updated properly', () => {
         cssStyler(stylerObj, "background-color", "black");
         assert.equal(stylerObj["backgroundColor"], "black");
@@ -69,10 +75,41 @@ describe('Styling Properties', () => {
         })[0];
         assert.exists(buttonModel);
     });
-    it('Initial button css properties are properly set', () => {
-        let buttonView = window.System.findViewById(buttonModel.id);
-        console.log(buttonView.style);
+    it('Initial button "cssStyle" BasicProperty is properly set', () => {
+        // Note we just test for some of the core style props as the
+        // complete list is likely to change in the future
+        let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
+        assert.equal(styleProp['visibility'], 'visible');
+        assert.equal(styleProp['textAlign'], 'center');
     });
-    it.skip('Updating the styling properties, updates the cssStyle property', () => {
+    it('Initial button DOM element style attribute is properly set', () => {
+        // Note we just test for some of the core style props as the
+        // complete list is likely to change in the future
+        let buttonView = window.System.findViewById(buttonModel.id);
+        assert.equal(buttonView.style['visibility'], 'visible');
+        assert.equal(buttonView.style['textAlign'], 'center');
+    });
+    it('Updating StyleProperty directly updates the "cssStyle" BasicProperty', () => {
+        buttonModel.partProperties.setPropertyNamed(buttonModel, "visible", false);
+        let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
+        assert.equal(styleProp['visibility'], 'hidden');
+    });
+    it('Updating StyleProperty directly updates the DOM element style attribute', () => {
+        let buttonView = window.System.findViewById(buttonModel.id);
+        assert.equal(buttonView.style['visibility'], 'hidden');
+    });
+    it('Updating StyleProperty via "set" message updates the "cssStyle" BasicProperty', () => {
+        let msg  = {
+            type: "command",
+            commandName: "setProperty",
+            args: ["visible", true]
+        };
+        buttonModel.sendMessage(msg, buttonModel);
+        let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
+        assert.equal(styleProp['visibility'], 'visible');
+    });
+    it('Updating StyleProperty via "set" updates the DOM element style attribute', () => {
+        let buttonView = window.System.findViewById(buttonModel.id);
+        assert.equal(buttonView.style['visibility'], 'visible');
     });
 });

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -1,0 +1,61 @@
+/**
+ *  Style and related property testing 
+ * ----------------------------------
+ */
+
+import chai from 'chai';
+const assert = chai.assert;
+const expect = chai.expect;
+import styler from '../utils/styler.js';
+
+let currentCardModel;
+let buttonModel;
+let stylerObj;
+
+describe('Styler Util', () => {
+    before(() => {
+        stylerObj = {};
+    });
+    it('Color style conversion', () => {
+        styler(stylerObj, "font-color", "red");
+        assert.equal("red", stylerObj["color"]);
+    });
+    it('Background Color style conversion', () => {
+        styler(stylerObj, "background-color", "red");
+        assert.equal("red", stylerObj["backgroundColor"]);
+    });
+    it('Styles updated properly', () => {
+        styler(stylerObj, "background-color", "black");
+        assert.equal("black", stylerObj["backgroundColor"]);
+        styler(stylerObj, "font-color", "black");
+        assert.equal("black", stylerObj["color"]);
+    });
+});
+
+describe.skip('Styling Properties', () => {
+    before(() => {
+        let currentCardView = document.querySelector('.current-stack > .current-card');
+        currentCardModel = currentCardView.model;
+        assert.exists(currentCardModel);
+        let addButton = function(){
+            let msg = {
+                type: 'command',
+                commandName: 'newModel',
+                args: [
+                    'button',
+                    currentCardModel.id,
+                    'card'
+                ]
+            };
+            currentCardModel.sendMessage(msg, currentCardModel);
+        };
+        expect(addButton).to.not.throw(Error);
+        let button = currentCardModel.subparts.filter(subpart => {
+            return subpart.type == 'button';
+        })[0];
+        buttonModel = button;
+        assert.exists(buttonModel);
+    });
+    it('Updaing the styling properties, updates the cssStyle property', () => {
+    });
+});

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -6,33 +6,47 @@
 import chai from 'chai';
 const assert = chai.assert;
 const expect = chai.expect;
-import styler from '../utils/styler.js';
+import cssStyler from '../utils/styler.js';
 
 let currentCardModel;
 let buttonModel;
 let stylerObj;
 
-describe('Styler Util', () => {
+describe('CSS Styler Util', () => {
     before(() => {
         stylerObj = {};
     });
-    it('Color style conversion', () => {
-        styler(stylerObj, "font-color", "red");
-        assert.equal("red", stylerObj["color"]);
+    it('Text styles conversion', () => {
+        cssStyler(stylerObj, "text-color", "red");
+        assert.equal(stylerObj["color"], "red");
+        cssStyler(stylerObj, "font", "Times");
+        assert.equal(stylerObj["fontFamily"], "Times");
+    });
+    it('Name visibility', () => {
+        cssStyler(stylerObj, "name-visible", true);
+        assert.equal(stylerObj["color"], "red");
+        cssStyler(stylerObj, "name-visible", false);
+        assert.equal(stylerObj["color"], "transparent");
+    });
+    it('Visibility', () => {
+        cssStyler(stylerObj, "visible", true);
+        assert.equal(stylerObj["visibility"], "visible");
+        cssStyler(stylerObj, "visible", false);
+        assert.equal(stylerObj["visibility"], "hidden");
     });
     it('Background Color style conversion', () => {
-        styler(stylerObj, "background-color", "red");
-        assert.equal("red", stylerObj["backgroundColor"]);
+        cssStyler(stylerObj, "background-color", "red");
+        assert.equal(stylerObj["backgroundColor"], "red");
     });
     it('Styles updated properly', () => {
-        styler(stylerObj, "background-color", "black");
-        assert.equal("black", stylerObj["backgroundColor"]);
-        styler(stylerObj, "font-color", "black");
-        assert.equal("black", stylerObj["color"]);
+        cssStyler(stylerObj, "background-color", "black");
+        assert.equal(stylerObj["backgroundColor"], "black");
+        cssStyler(stylerObj, "text-color", "black");
+        assert.equal(stylerObj["color"], "black");
     });
 });
 
-describe.skip('Styling Properties', () => {
+describe('Styling Properties', () => {
     before(() => {
         let currentCardView = document.querySelector('.current-stack > .current-card');
         currentCardModel = currentCardView.model;
@@ -50,12 +64,15 @@ describe.skip('Styling Properties', () => {
             currentCardModel.sendMessage(msg, currentCardModel);
         };
         expect(addButton).to.not.throw(Error);
-        let button = currentCardModel.subparts.filter(subpart => {
+        buttonModel = currentCardModel.subparts.filter(subpart => {
             return subpart.type == 'button';
         })[0];
-        buttonModel = button;
         assert.exists(buttonModel);
     });
-    it('Updaing the styling properties, updates the cssStyle property', () => {
+    it('Initial button css properties are properly set', () => {
+        let buttonView = window.System.findViewById(buttonModel.id);
+        console.log(buttonView.style);
+    });
+    it.skip('Updating the styling properties, updates the cssStyle property', () => {
     });
 });

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -46,6 +46,10 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         _setOrNot(styleObj, "textStyle",  propertyValue);
         break;
 
+    case "rotate":
+        _setOrNot(styleObj, "transform",  _intToRotateDeg(propertyValue));
+        break;
+
     case "name-visible":
         if(propertyValue === false){
             styleObj["color"] = "transparent";
@@ -82,6 +86,15 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
 const _setOrNot = (styleObj, name, value) => {
     if(value !== null && value !== undefined){
         styleObj[name] = value;
+    }
+}
+
+const _intToRotateDeg = (n) => {
+    if(n !== null && n !== undefined){
+        if(typeof(n) === "string"){
+            n = n.split("deg")[0];
+        }
+        return `rotate(${n}deg)`;
     }
 }
 

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -1,0 +1,27 @@
+/**
+ * Styler
+ * ------------------------------------
+ * I am responsible for converting
+ * SimpleTalk visual styling to a dict
+ * Object of CSS JavaScript type key-value pairs
+ */
+
+/** I style the styleObj
+ * styleObj: css JavaScript key:value pairs
+ * propertyName: (SimpleTalk) styling property name
+ * propertyValue: (SimpleTalk) styling property value
+ */
+const styler = (styleObj, propertyName, propertyValue) => {
+    switch(propertyName){
+    case "background-color":
+        styleObj["backgroundColor"] = propertyValue;
+    case "font-color":
+        styleObj["color"] = propertyValue;
+    }
+
+};
+
+export {
+    styler,
+    styler as default
+};

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -54,6 +54,14 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
             styleObj["visibility"] = "visible";
         }
         break;
+
+    default:
+        // for the default we simply allow ST style names to map 1-1
+        // to CSS/JS style names. This is only somewhat safe, since the DOM
+        // will simply ignore nonsense names without throwing an error. But it
+        // does allow us to avoid writing a rule for every term (example: width,
+        // height, top, left etc)
+        _setOrNot(styleObj, propertyName,  propertyValue);
     }
     return styleObj;
 

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -34,6 +34,14 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         _setOrNot(styleObj, "textAlign",  propertyValue);
         break;
 
+    case "top":
+        _setOrNot(styleObj, "top",  _intToPx(propertyValue));
+        break;
+
+    case "left":
+        _setOrNot(styleObj, "left",  _intToPx(propertyValue));
+        break;
+
     case "text-style":
         _setOrNot(styleObj, "textStyle",  propertyValue);
         break;
@@ -74,6 +82,16 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
 const _setOrNot = (styleObj, name, value) => {
     if(value !== null && value !== undefined){
         styleObj[name] = value;
+    }
+}
+
+
+const _intToPx = (n) => {
+    if(n !== null && n !== undefined){
+        if(typeof(n) === "string"){
+            n = n.split("px")[0];
+        }
+        return `${n}px`;
     }
 }
 

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -41,6 +41,8 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
     case "name-visible":
         if(propertyValue === false){
             styleObj["color"] = "transparent";
+        } else {
+            styleObj["color"] = "initial";
         }
         break;
 

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -11,17 +11,45 @@
  * propertyName: (SimpleTalk) styling property name
  * propertyValue: (SimpleTalk) styling property value
  */
-const styler = (styleObj, propertyName, propertyValue) => {
+const cssStyler = (styleObj, propertyName, propertyValue) => {
     switch(propertyName){
+
     case "background-color":
         styleObj["backgroundColor"] = propertyValue;
-    case "font-color":
+
+    case "text-color":
         styleObj["color"] = propertyValue;
+
+    case "font":
+        styleObj["fontFamily"] = propertyValue;
+
+    case "text-size":
+        styleObj["fontSize"] = propertyValue;
+
+    case "text-align":
+        styleObj["textAlign"] = propertyValue;
+
+    case "text-style":
+        styleObj["textStyle"] = propertyValue;
+
+    case "name-visible":
+        if(propertyValue === false){
+            styleObj["color"] = "transparent";
+        }
+
+    case "visible":
+        // TODO should this really be using the 'display' css prop
+        if(propertyValue === false){
+            styleObj["visibility"] = "hidden";
+        } else if(propertyValue === true){
+            styleObj["visibility"] = "visible";
+        }
     }
+    return styleObj;
 
 };
 
 export {
-    styler,
-    styler as default
+    cssStyler,
+    cssStyler as default
 };

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -15,27 +15,34 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
     switch(propertyName){
 
     case "background-color":
-        styleObj["backgroundColor"] = propertyValue;
+        _setOrNot(styleObj, "backgroundColor",  propertyValue);
+        break;
 
     case "text-color":
-        styleObj["color"] = propertyValue;
+        _setOrNot(styleObj, "color",  propertyValue);
+        break;
 
     case "font":
-        styleObj["fontFamily"] = propertyValue;
+        _setOrNot(styleObj, "fontFamily",  propertyValue);
+        break;
 
     case "text-size":
-        styleObj["fontSize"] = propertyValue;
+        _setOrNot(styleObj, "fontSize", propertyValue);
+        break;
 
     case "text-align":
-        styleObj["textAlign"] = propertyValue;
+        _setOrNot(styleObj, "textAlign",  propertyValue);
+        break;
 
     case "text-style":
-        styleObj["textStyle"] = propertyValue;
+        _setOrNot(styleObj, "textStyle",  propertyValue);
+        break;
 
     case "name-visible":
         if(propertyValue === false){
             styleObj["color"] = "transparent";
         }
+        break;
 
     case "visible":
         // TODO should this really be using the 'display' css prop
@@ -44,10 +51,21 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         } else if(propertyValue === true){
             styleObj["visibility"] = "visible";
         }
+        break;
     }
     return styleObj;
 
 };
+
+// In order to avoid clashing with views interacting
+// the style attribute directly we ignore everything that
+// is either null or undefined
+// TODO review this decision!
+const _setOrNot = (styleObj, name, value) => {
+    if(value !== null && value !== undefined){
+        styleObj[name] = value;
+    }
+}
 
 export {
     cssStyler,

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -7,10 +7,6 @@ import PartView from './PartView.js';
 
 const templateString = `
                 <style>
-                 :host(.editing){
-                     background-color: white;
-                     color: black;
-                 }
                  .st-button-label {
                      user-select: none;
                      pointer-events: none;

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -50,7 +50,7 @@ class ButtonView extends PartView {
         this.onPropChange('background-color', (value) => {
             this.style.backgroundColor = value;
         });
-        this.onPropChange('font-color', (value) =>{
+        this.onPropChange('text-color', (value) =>{
             this.style.color = value;
         });
         this.onPropChange("draggable", (value) => {

--- a/js/objects/views/CardView.js
+++ b/js/objects/views/CardView.js
@@ -29,7 +29,6 @@ class CardView extends PartView {
         this.onDrop = this.onDrop.bind(this);
         this.setupPropHandlers = this.setupPropHandlers.bind(this);
         this.layoutChanged = this.layoutChanged.bind(this);
-        this.bgColorChanged = this.bgColorChanged.bind(this);
 
         // Setup prop handlers
         this.setupPropHandlers();
@@ -37,7 +36,6 @@ class CardView extends PartView {
 
     setupPropHandlers(){
         this.onPropChange('layout', this.layoutChanged);
-        this.onPropChange('backgroundColor', this.bgColorChanged);
     }
 
     afterConnected(){
@@ -96,7 +94,7 @@ class CardView extends PartView {
                 commandName : "copyModel",
                 args: [sourceModelId, this.model.id],
                 shouldIgnore: true
-            }
+            };
             this.sendMessage(msg, sourceModel);
         }
     }
@@ -122,20 +120,8 @@ class CardView extends PartView {
         } else if(layout && listDirection){
             this.classList.add('list-column');
         }
-        // background stuff
-        let backgroundColor = this.model.partProperties.getPropertyNamed(
-            this.model,
-            'backgroundColor'
-        );
-        this.style['backgroundColor'] = backgroundColor;
-        // TODO this could bemore propgrammatic. For example
-        // styleProperties((prop) => {this.style[prop.name] = prop.value}) etc
     }
 
-    // TODO: this shold be a more general prop change handler
-    bgColorChanged(value){
-        this.style['backgroundColor'] = value;
-    }
 };
 
 export {

--- a/js/objects/views/ContainerView.js
+++ b/js/objects/views/ContainerView.js
@@ -83,11 +83,13 @@ class ContainerView extends PartView {
     openHalo(){
         // Compute the appropriate width and height from
         // current rect
+        /*
         let rect = this.getBoundingClientRect();
         this.style.width = `${Math.floor(rect.width)}px`;
         this.style.height = `${Math.floor(rect.height)}px`;
         this.style.top = `${Math.floor(rect.top)}px`;
         this.style.left = `${Math.floor(rect.left)}px`;
+        */
         let foundHalo = this._shadowRoot.querySelector('st-halo');
         if(foundHalo){
             this._shadowRoot.removeChild(foundHalo);

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -28,11 +28,8 @@ const templateString = `
     display: flex;
     align-items: center;
     flex-direction: column;
-    max-height: 100%important;
     height: 100%;
     width: 100%;
-    overflow-y: auto;
-    overflow-x: hidden;
 }
 
 .field color-wheel {
@@ -42,7 +39,6 @@ const templateString = `
 .field-textarea-wrapper {
     width: 100%;
     height: 100%;
-    min-height: 300px;
     background-color: var(--palette-cornsik);
     overflow: auto;
 }
@@ -60,8 +56,6 @@ const templateString = `
     justify-content: center;
     width: 100%;
     background-color: var(--palette-red);
-    padding-top: 5px;
-    padding-bottom: 5px;
     opacity: 1;
     transition: opacity .5s, transform 1s;
 }
@@ -73,17 +67,6 @@ const templateString = `
 
 .field-toolbar > *:active {
     outline: 2px solid #004b67;
-}
-
-:host {
-    display: block;
-    position: absolute;
-    outline: none;
-    resize: both;
-}
-:host(:active),
-:host(:focus){
-    outline: none;
 }
 </style>
 <div class="field">

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -224,14 +224,14 @@ class Halo extends HTMLElement {
     }
 
     onMouseMove(event){
-        let currentTop = this.targetElement.offsetTop;
-        let currentLeft = this.targetElement.offsetLeft;
+        let currentTop = parseInt(this.targetElement.style.top);
+        let currentLeft = parseInt(this.targetElement.style.left);
         let newTop = event.movementY + currentTop;
         let newLeft = event.movementX + currentLeft;
 
         let model = this.targetElement.model;
-        model.partProperties.setPropertyNamed(model, "top", `${newTop}px`);
-        model.partProperties.setPropertyNamed(model, "left", `${newLeft}px`);
+        model.partProperties.setPropertyNamed(model, "top", newTop);
+        model.partProperties.setPropertyNamed(model, "left", newLeft);
     }
 
     onMouseUp(event){

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -251,28 +251,6 @@ class Halo extends HTMLElement {
     }
 
     onResizeMouseMove(event){
-        // let rect = this.targetElement.getBoundingClientRect();
-        // let newWidth, newHeight;
-        // if(this.targetElement.preserveAspectOnResize){
-        //     let ratio = rect.width / rect.height;
-        //     let hyp = Math.sqrt((event.movementX**2) + (event.movementY**2));
-        //     if(event.movementX < 0 || event.movementY < 0){
-        //         hyp = hyp * -1;
-        //     }
-        //     newHeight = rect.height + hyp;
-        //     newWidth = rect.width + hyp;
-        // } else {
-        //     newWidth = event.movementX + rect.width;
-        //     newHeight = event.movementY + rect.height;
-        // }
-        // this.targetElement.style.width = `${newWidth}px`;
-        // this.targetElement.style.height = `${newHeight}px`;
-        // if(this.targetElement.onHaloResize){
-        //     this.targetElement.onHaloResize(
-        //         event.movementX,
-        //         event.movementY
-        //     );
-        // }
         this.targetElement.onHaloResize(
             event.movementX,
             event.movementY

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -229,8 +229,9 @@ class Halo extends HTMLElement {
         let newTop = event.movementY + currentTop;
         let newLeft = event.movementX + currentLeft;
 
-        this.targetElement.style.top = `${newTop}px`;
-        this.targetElement.style.left = `${newLeft}px`;
+        let model = this.targetElement.model;
+        model.partProperties.setPropertyNamed(model, "top", `${newTop}px`);
+        model.partProperties.setPropertyNamed(model, "left", `${newLeft}px`);
     }
 
     onMouseUp(event){

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -106,6 +106,7 @@ class PartView extends HTMLElement {
         // Do not override this method
         // TODO: Implement the universals
         this.onPropChange('script', this.scriptChanged);
+        this.onPropChange('cssStyle', this.styleCSS);
         this.onPropChange('eventRespond', this.eventRespond);
         this.onPropChange('eventIgnore', this.eventIgnore);
         this.onPropChange('editorOpen', (value) => {
@@ -119,14 +120,9 @@ class PartView extends HTMLElement {
 
     styleCSS(){
         let cssStyle = this.model.partProperties.getPropertyNamed(this, "cssStyle");
-        console.log(cssStyle);
-        Object.keys((key) => {
-            // null and undefined are assumed to do nothing to the styling to
-            // allow for various stylesheet and related css settings
+        Object.keys(cssStyle).forEach((key) => {
             let value = cssStyle[key];
-            if(value!== null && value!==undefined){
-                this.style[key] = value;
-            }
+            this.style[key] = value;
         });
     }
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -32,6 +32,9 @@ class PartView extends HTMLElement {
         this.sendMessage = this.sendMessage.bind(this);
         this.setupBasePropHandlers = this.setupBasePropHandlers.bind(this);
 
+        // Bind initial property method
+        this.styleCSS = this.styleCSS.bind(this);
+
         // Bind property change reaction methods
         this.primHandlePropChange = this.primHandlePropChange.bind(this);
         this.onPropChange = this.onPropChange.bind(this);
@@ -83,6 +86,8 @@ class PartView extends HTMLElement {
         // the latter can technically be invoked before the model is set
         let events = this.model.partProperties.getPropertyNamed(this.model, "events");
         events.forEach((eventRespond) => this.eventRespond(eventRespond));
+        // load all the initial styling
+        this.styleCSS();
         this.afterModelSet();
     }
 
@@ -108,6 +113,19 @@ class PartView extends HTMLElement {
                 this.openEditor();
             } else if(value === false){
                 this.closeEditor();
+            }
+        });
+    }
+
+    styleCSS(){
+        let cssStyle = this.model.partProperties.getPropertyNamed(this, "cssStyle");
+        console.log(cssStyle);
+        Object.keys((key) => {
+            // null and undefined are assumed to do nothing to the styling to
+            // allow for various stylesheet and related css settings
+            let value = cssStyle[key];
+            if(value!== null && value!==undefined){
+                this.style[key] = value;
             }
         });
     }

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -306,8 +306,8 @@ class PartView extends HTMLElement {
             newWidth = event.movementX + rect.width;
             newHeight = event.movementY + rect.height;
         }
-        this.style.width = `${newWidth}px`;
-        this.style.height = `${newHeight}px`;
+        this.model.partProperties.setPropertyNamed(this.model, "width", `${newWidth}px`);
+        this.model.partProperties.setPropertyNamed(this.model, "height", `${newHeight}px`);
     }
 
     get wantsHaloMove(){
@@ -323,7 +323,7 @@ class PartView extends HTMLElement {
             parentModel,
             'layout'
         );
-        if(!parentLayout || parentLayout == ""){
+        if(parentLayout === 'absolute' | !parentLayout || parentLayout == ""){
             return true;
         }
 

--- a/js/objects/views/StackView.js
+++ b/js/objects/views/StackView.js
@@ -15,11 +15,7 @@ import Stack from '../parts/Stack.js';
 // the current stack, or else they have the class
 // window-stack (suggesting there's window part
 // who wishes to display it)
-const templateString = `
-                <style>
-                </style>
-                <slot></slot>
-`;
+const templateString = `<slot></slot>`;
 
 class StackView extends PartView {
     constructor(){

--- a/js/objects/views/WindowView.js
+++ b/js/objects/views/WindowView.js
@@ -217,8 +217,8 @@ class WindowView extends PartView {
         let currentLeft = parseInt(this.style.left);
         let newTop = `${currentTop + event.movementY}px`;
         let newLeft = `${currentLeft + event.movementX}px`;
-        this.style.top = newTop;
-        this.style.left = newLeft;
+        this.model.partProperties.setPropertyNamed(this.model, "top", newTop);
+        this.model.partProperties.setPropertyNamed(this.model, "left", newLeft);
     }
 
     onGripUp(event){

--- a/js/objects/views/WorldView.js
+++ b/js/objects/views/WorldView.js
@@ -10,27 +10,7 @@
  */
 import PartView from './PartView.js';
 
-const templateString = `
-                <style>
-                 #available-stacks {
-                     display: block;
-                     width: 100%;
-                     height: 100%;
-                     position: relative;
-                 }
-
-                 #available-stacks > st-stack {
-                     display: none;
-                 }
-
-                 #available-stacks > st-stack.current-stack {
-                     display: inherit;
-                 }
-                </style>
-                <div id="available-stacks">
-                    <slot></slot>
-                </div>
-`;
+const templateString = `<slot></slot>`;
 
 class WorldView extends PartView {
     constructor(){

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -118,7 +118,7 @@ position: absolute;
     </div>
     <button class="script">Script</button>
     <button class="background-color" name="background-color">Background Color</button>
-    <button class="font-color" name="font-color">Font Color</button>
+    <button class="text-color" name="text-color">Font Color</button>
 </div>
 `;
 
@@ -181,7 +181,7 @@ class ButtonEditorView extends HTMLElement {
         nameInput.removeEventListener('input', this.onNameInput);
         let backgroundButton = this._shadowRoot.querySelector('button.background-color');
         backgroundButton.removeEventListener('click', this.openColorWheelWidget);
-        let colorButton = this._shadowRoot.querySelector('button.font-color');
+        let colorButton = this._shadowRoot.querySelector('button.text-color');
         let eventsDiv = this._shadowRoot.querySelector('.editor-main > div.events-display');
         let eventsInput = eventsDiv.querySelector('input.events');
         eventsInput.removeEventListener('keydown', this.onEventInputKeydown);
@@ -228,7 +228,7 @@ class ButtonEditorView extends HTMLElement {
         nameInput.addEventListener('input', this.onNameInput);
         let backgroundButton = this._shadowRoot.querySelector('button.background-color');
         backgroundButton.addEventListener('click', this.openColorWheelWidget);
-        let colorButton = this._shadowRoot.querySelector('button.font-color');
+        let colorButton = this._shadowRoot.querySelector('button.text-color');
         colorButton.addEventListener('click', this.openColorWheelWidget);
         let eventsDiv = this._shadowRoot.querySelector('.editor-main > div.events-display');
         let eventsInput = eventsDiv.querySelector('input.events');

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -203,7 +203,7 @@
 		| "answer" (stringLiteral | variableName) --answer
 		| "delete" "this"? systemObject objectId? --deleteModel
 		| "add" systemObject stringLiteral? "to"? ("this" | "current")? systemObject? objectId? --addModel
-		| "set" stringLiteral "to" (stringLiteral | variableName) InClause? --setProperty
+		| "set" stringLiteral "to" (stringLiteral | variableName | integerLiteral ) InClause? --setProperty
 		| "put" Factor "into" "global"? variableName --putVariable
 		| "ask" anyLiteral --ask
 		| "respond to" anyLiteral InClause? --eventRespond


### PR DESCRIPTION
### Main Points ###

Here we refactor and cleanup the css, which includes the [core.css](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-css-refactoring?expand=1#diff-c753a1396e7b4b55330c513675b157cc4aed6cb4508b6f00831bf44d20183c4d) as well as all the shadow styling that happens in custom web components themselves. The idea was to set as much of the general styling in the [core.css](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-css-refactoring?expand=1#diff-c753a1396e7b4b55330c513675b157cc4aed6cb4508b6f00831bf44d20183c4d) file,  insisting that the shadow element sub-DOM would respond to this top level setting (to would allow for more explicitness and work well with controlling styles programmatically). This was largely successful, outside of `st-drawing` which interfaces with the internal canvas for sizing. In addition, I wanted the css to reflect our hierarchy structure, i.e. that `st-world` and `st-stack` are invisible, `st-card`'s take up the entire view-port of their parent (that being global view or a window) etc. 

Finally, the entire styling framework was refactored with the introduction of the [StyleProperty](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-css-refactoring?expand=1#diff-c2dd5e63907f075364f2f774ef3baf2eeb51ce74c56cf051254b75bbacf3b90aR123) and a [styler](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-css-refactoring?expand=1#diff-a7207430ea89f77a30ee56b19e948f99e4b298a5dba4a0f727ae30fbe0012c59) with its various utilities. The basic idea was to create a fully scriptable styling interface and also to completely decouple the SimpleTalk styling semantics with anything outside. For example, the [styler](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-css-refactoring?expand=1#diff-a7207430ea89f77a30ee56b19e948f99e4b298a5dba4a0f727ae30fbe0012c59) function seen here is a specific `cssStyler` but in practice `StyleProperty` can take any function which transforms incoming SimpleTalk to something that a rendering engine can understand. We can have multiple system-wide stylers to play with, or use multiple within the same system. 

#### Notes ####
I've removed (most) of the style related props in PartView, replaced what was needed with the new `StyleProperty`'s in both PartView and its subclasses. At the moment I just stuck with keeping things to a minimum but also made decisions which seemed sensible. For example: removing all position and size from `PartView` since only some views really need this; adding these to views like window, field, etc... 

When a view is first instantiated, it can call a `setupStyleProperties()` from its `PartView` subclass. Note, this is not called automatically since not all views have styling properties and not all views might want to call these at instantiation (debatable). Instead of adding some sort of "type" attribute to all properties and using that, this method simply goes through all and picks out those that are instances of the `StyleProperty` class. This is fine for the moment I think but if we have more props types flying around, better design might be needed. 

With that said `PartView` has a `cssStyle` `BasicProperty` which is a dict/object containing css/JS valid key-values. This is what `StyleProperty` acts on when it is changed and it does so via the supplied styler. So in a sense `StyleProperty` is a particular type of `DynamicProperty`.  It is important to note that the `styler` alters the **entire** style object supplied to it, potentially altering multiple key-values, removing some, adding others, and does so in a way completely independent of the system or view or anything like that. So we are not married to a 1-1 mapping of ST style to css style.

This `cssStyle` property is what every view subscribes to, by simply updating `this.style` DOM element attribute. 

Halo and window moves now work with these properties not the DOM element style directly. This way there is no potential of mismatch (again with the exception of size for drawing, canvas..) 

I added a [`rotate` property](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-css-refactoring?expand=1#diff-a7207430ea89f77a30ee56b19e948f99e4b298a5dba4a0f727ae30fbe0012c59R49) which translates to a css `transform: rotate(N)` as an example of what we can do, and also because it's fun. You can see that if we wanted to add say a "translate" ST property, our styler would need to update the `transform` key-value in `cssStyle` instead of just overwriting it, i.e. a rotate and translate would result in `transform: rotate(N) translate(X)` css. Anyhow we have a lot of room to play with. 

#### Tests ####
Tests have been written for the styler and related property change dynamics. Older tests have been updated/fixed to reflect the new structure. 

This is rebased over `master` as of #105 PR. 