### PR TITLE
Adding built in 'tell' command

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -1497,6 +1497,14 @@ System._commandHandlers['saveHTML'] = function(senders){
     anchor.parentElement.removeChild(anchor);
 };
 
+System._commandHandlers['tell'] = (senders, targetId, deferredMessage) => {
+    let targetPart = System.partsById[targetId];
+    if(!targetPart){
+        throw new Error(`Attempted to tell part id ${targetId}: no such part!`);
+    }
+    targetPart.sendMessage(deferredMessage, targetPart);
+};
+
 System._commandHandlers['startVideo'] = () => {
     if (video.srcObject !== null) {
         return;
@@ -1522,14 +1530,14 @@ System._commandHandlers['stopVideo'] = () => {
 // https://aaronsmith.online/easily-load-an-external-script-using-javascript/
 const loadScript = src => {
     return new Promise((resolve, reject) => {
-        const script = document.createElement('script')
-        script.type = 'text/javascript'
-        script.onload = resolve
-        script.onerror = reject
-        script.src = src
-        document.head.append(script)
-    })
-}
+        const script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.onload = resolve;
+        script.onerror = reject;
+        script.src = src;
+        document.head.append(script);
+    });
+};
 
 const loadHandDetectionModel = () => {
     if (handDetectionModel === null) {
@@ -1628,7 +1636,7 @@ System._commandHandlers['detectHands'] = (senders, recipientId) => {
         }
     }
     detectHands(recipientId);
-}
+};
 
 
 /** Register the initial set of parts in the system **/

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -258,6 +258,17 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             };
         },
 
+        Command_tellCommand: function(tellLiteral, objectSpecifier, toLiteral, command){
+            return {
+                type: 'command',
+                commandName: 'tell',
+                args: [
+                    objectSpecifier.interpret(),
+                    command.interpret()
+                ]
+            };
+        },
+
         Command_arbitraryCommand: function(commandName, optionalArgumentList){
             // Because the argument list is optional here, it will
             // be either an empty array (no arguments) or a size 1
@@ -671,13 +682,13 @@ const createInterpreterSemantics = (partContext, systemContext) => {
                     if(partContext.type == 'card'){
                         return partContext;
                     } else {
-                        return findNearestParentOfKind(targetType);
+                        return findNearestParentOfKind(partContext, targetType);
                     }
                 } else if(targetType == 'stack'){
                     if(partContext.type == 'stack'){
                         return partContext;
                     } else {
-                        return findNearestParentOfKind(targetType);
+                        return findNearestParentOfKind(partContext, targetType);
                     }
                 } else {
                     // If we reach this point, we expect the systemObject
@@ -718,8 +729,8 @@ const createInterpreterSemantics = (partContext, systemContext) => {
          * Examples: `card id 266` `part id 5`
          */
         TerminalSpecifier_partById: function(objectType, idLiteral, objectId){
-            let id = objectId.interpret();
-            let found = systemContext.partsById[id];
+            let id = objectId.sourceString;
+            let found = systemContext.partsById[parseInt(id)];
             if(!found){
                 throw new Error(`Cannot find ${objectType.sourceString} with id ${objectId}`);
             }

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -208,6 +208,7 @@
 		| "ask" anyLiteral --ask
 		| "respond to" anyLiteral InClause? --eventRespond
 		| "ignore" anyLiteral InClause? --eventIgnore
+                | "tell" ObjectSpecifier "to" Command --tellCommand
 		| messageName CommandArgumentList? --arbitraryCommand
 
 	CommentLines

--- a/js/ohm/tests/test-tell-grammar.js
+++ b/js/ohm/tests/test-tell-grammar.js
@@ -1,0 +1,35 @@
+/** Test grammar of the new 'tell' command **/
+ohm = require('ohm-js');
+// Instantiate the grammar.
+var fs = require('fs');
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+
+var chai = require('chai');
+var assert = chai.assert;
+
+const matchTest = (str) => {
+    const match = g.match(str);
+    assert.isTrue(match.succeeded());
+};
+const semanticMatchTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isTrue(typeMatch.succeeded());
+};
+
+const semanticMatchFailTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isFalse(typeMatch.succeeded());
+};
+
+describe('#tell command tests', () => {
+    describe("Simple ObjectSpecifiers", () => {
+        it("Can tell this card to perform some arbitrary command with args", () => {
+            let str = `tell this card to myCustomCommand 3, "hello", -0.5`;
+            semanticMatchTest(str, 'Command_tellCommand');
+        });
+        it("Can tell a nested specifier to perform an arbitrary command", () => {
+            let str = `tell second button of card 5 of stack "myStack" to myCustomCommand 3, "hello", -0.3`;
+            semanticMatchTest(str, 'Command_tellCommand');
+        });
+    });
+});


### PR DESCRIPTION
## What
The tell sends a command message to some other specified part. This is
a way of sending messages outside of the message delegation chain.

It takes the form of:
   `tell <ObjectSpecifier> to <Command>`

For example:
```simpletalk
    tell first image of this card to loadFromUrl "http://some-image-source"
```
Note that the message is a deferred one. The tell command's first
argument is the id of the part that should execute it, and the second
argument is a correctly formatted command message object. The target,
once found, will simply send that second argument to itself. This
means that the part invoking the 'tell' command originally *will not
appear in the message's senders list*. This is what we'd expect, since
it is essentially "spoofing" the message send.