### PR TITLE
transparent

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -157,6 +157,7 @@ st-field {
     width: var(--field-default-width);
     height: var(--field-default-height);
     position: absolute;
+    background-color: var(--palette-cornsik);
 }
 
 

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -54,11 +54,15 @@ class Button extends Part {
         );
         this.partProperties.newStyleProp(
             'background-color',
-            null,
+            "rgba(255, 234, 149, 1)", // var(--palette-yellow)
+        );
+        this.partProperties.newStyleProp(
+            'background-transparency',
+            1,
         );
         this.partProperties.newStyleProp(
             'text-color',
-            "rgba(0, 0, 0, 1)",
+            "rgba(0, 0, 0, 1)", // black
         );
         this.partProperties.newStyleProp(
             'text-style',

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -65,7 +65,7 @@ class Button extends Part {
             'plain',
         );
         this.partProperties.newStyleProp(
-            'text-tranparency',
+            'text-transparency',
             1,
         );
         this.partProperties.newStyleProp(

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -95,6 +95,10 @@ class Button extends Part {
             'rotate',
             null,
         );
+        this.partProperties.newStyleProp(
+            'transparent',
+            false,
+        );
         // TODO tbd props
         this.partProperties.newBasicProp(
             'autoHilite',

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -58,19 +58,19 @@ class Button extends Part {
         );
         this.partProperties.newStyleProp(
             'text-color',
-            null,
+            "rgba(0, 0, 0, 1)",
         );
         this.partProperties.newStyleProp(
             'text-style',
             'plain',
         );
         this.partProperties.newStyleProp(
-            'name-visible',
-            true,
+            'text-tranparency',
+            1,
         );
         this.partProperties.newStyleProp(
-            'visible',
-            true,
+            'hide',
+            false,
         );
         // setting width and height to null
         // effectively forces to the default size
@@ -96,8 +96,8 @@ class Button extends Part {
             null,
         );
         this.partProperties.newStyleProp(
-            'transparent',
-            false,
+            'transparency',
+            1.0,
         );
         // TODO tbd props
         this.partProperties.newBasicProp(

--- a/js/objects/parts/Container.js
+++ b/js/objects/parts/Container.js
@@ -48,6 +48,14 @@ class Container extends Part {
             'rotate',
             null
         );
+        this.partProperties.newStyleProp(
+            'visible',
+            true,
+        );
+        this.partProperties.newStyleProp(
+            'transparent',
+            false,
+        );
         this.setupStyleProperties();
     }
 

--- a/js/objects/parts/Container.js
+++ b/js/objects/parts/Container.js
@@ -49,12 +49,12 @@ class Container extends Part {
             null
         );
         this.partProperties.newStyleProp(
-            'visible',
-            true,
+            'hide',
+            false,
         );
         this.partProperties.newStyleProp(
-            'transparent',
-            false,
+            'transparency',
+            1.0,
         );
         this.setupStyleProperties();
     }

--- a/js/objects/parts/Container.js
+++ b/js/objects/parts/Container.js
@@ -29,6 +29,10 @@ class Container extends Part {
             null,
         );
         this.partProperties.newStyleProp(
+            'background-transparency',
+            1,
+        );
+        this.partProperties.newStyleProp(
             'width',
             "300px",
         );
@@ -44,7 +48,7 @@ class Container extends Part {
             'left',
             "0",
         );
-        this.partProperties.newStuyleProp(
+        this.partProperties.newStyleProp(
             'rotate',
             null
         );

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -190,7 +190,6 @@ class Drawing extends Part {
         );
         this.activeCanvas = null;
         this.activeContext = null;
-        
     }
 
     /* Utility Methods for Scriptable Drawing */

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -30,6 +30,14 @@ class Drawing extends Part {
             'rotate',
             null
         );
+        this.partProperties.newStyleProp(
+            'visible',
+            true,
+        );
+        this.partProperties.newStyleProp(
+            'transparent',
+            false,
+        );
         this.setupStyleProperties();
 
         // When drawing from a script/commands,

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -31,12 +31,12 @@ class Drawing extends Part {
             null
         );
         this.partProperties.newStyleProp(
-            'visible',
-            true,
+            'hide',
+            false,
         );
         this.partProperties.newStyleProp(
-            'transparent',
-            false,
+            'transparency',
+            1.0,
         );
         this.setupStyleProperties();
 

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -118,12 +118,12 @@ class Field extends Part {
             'default',
         );
         this.partProperties.newStyleProp(
-            'text-transparency',
-            1.0,
+            'background-color',
+            "rgb(255, 248, 220, 1)", // var(--palette-cornsik)
         );
         this.partProperties.newStyleProp(
-            'background-color',
-            null,
+            'background-transparency',
+            1.0,
         );
         this.partProperties.newStyleProp(
             'text-color',

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -101,6 +101,14 @@ class Field extends Part {
             'rotate',
             null
         );
+        this.partProperties.newStyleProp(
+            'visible',
+            true,
+        );
+        this.partProperties.newStyleProp(
+            'transparent',
+            false,
+        );
         this.setupStyleProperties();
     }
 

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -110,8 +110,16 @@ class Field extends Part {
             1.0,
         );
         this.partProperties.newStyleProp(
+            'text-transparency',
+            1.0,
+        );
+        this.partProperties.newStyleProp(
             'text-font',
             'default',
+        );
+        this.partProperties.newStyleProp(
+            'text-transparency',
+            1.0,
         );
         this.partProperties.newStyleProp(
             'background-color',

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -102,12 +102,24 @@ class Field extends Part {
             null
         );
         this.partProperties.newStyleProp(
-            'visible',
-            true,
+            'hide',
+            false,
         );
         this.partProperties.newStyleProp(
-            'transparent',
-            false,
+            'transparency',
+            1.0,
+        );
+        this.partProperties.newStyleProp(
+            'text-font',
+            'default',
+        );
+        this.partProperties.newStyleProp(
+            'background-color',
+            null,
+        );
+        this.partProperties.newStyleProp(
+            'text-color',
+            "rgba(0, 0, 0, 1)",
         );
         this.setupStyleProperties();
     }

--- a/js/objects/parts/Image.js
+++ b/js/objects/parts/Image.js
@@ -53,6 +53,14 @@ class Image extends Part {
             'rotate',
             null
         );
+        this.partProperties.newStyleProp(
+            'visible',
+            true,
+        );
+        this.partProperties.newStyleProp(
+            'transparent',
+            false,
+        );
         this.setupStyleProperties();
 
         // Private command handlers

--- a/js/objects/parts/Image.js
+++ b/js/objects/parts/Image.js
@@ -54,12 +54,12 @@ class Image extends Part {
             null
         );
         this.partProperties.newStyleProp(
-            'visible',
-            true,
+            'hide',
+            false,
         );
         this.partProperties.newStyleProp(
-            'transparent',
-            false,
+            'transparency',
+            1.0,
         );
         this.setupStyleProperties();
 

--- a/js/objects/parts/Window.js
+++ b/js/objects/parts/Window.js
@@ -59,6 +59,14 @@ class Window extends Part {
             'rotate',
             null
         );
+        this.partProperties.newStyleProp(
+            'visible',
+            true,
+        );
+        this.partProperties.newStyleProp(
+            'transparent',
+            false,
+        );
         this.setupStyleProperties();
 
         // Bind methods

--- a/js/objects/parts/Window.js
+++ b/js/objects/parts/Window.js
@@ -60,12 +60,12 @@ class Window extends Part {
             null
         );
         this.partProperties.newStyleProp(
-            'visible',
-            true,
+            'hide',
+            false,
         );
         this.partProperties.newStyleProp(
-            'transparent',
-            false,
+            'transparency',
+            1.0,
         );
         this.setupStyleProperties();
 

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -28,11 +28,17 @@ describe('CSS Styler Util', () => {
         cssStyler(stylerObj, "name-visible", false);
         assert.equal(stylerObj["color"], "transparent");
     });
+    it('Transparency', () => {
+        cssStyler(stylerObj, "transparent", false);
+        assert.equal(stylerObj["visibility"], "visible");
+        cssStyler(stylerObj, "transparent", true);
+        assert.equal(stylerObj["visibility"], "hidden");
+    });
     it('Visibility', () => {
         cssStyler(stylerObj, "visible", true);
-        assert.equal(stylerObj["visibility"], "visible");
+        assert.equal(stylerObj["display"], "initial");
         cssStyler(stylerObj, "visible", false);
-        assert.equal(stylerObj["visibility"], "hidden");
+        assert.equal(stylerObj["display"], "none");
     });
     it('Background Color style conversion', () => {
         cssStyler(stylerObj, "background-color", "red");
@@ -108,7 +114,7 @@ describe('Styling Properties', () => {
         assert.equal(buttonView.style['textAlign'], 'center');
     });
     it('Updating StyleProperty directly updates the "cssStyle" BasicProperty', () => {
-        buttonModel.partProperties.setPropertyNamed(buttonModel, "visible", false);
+        buttonModel.partProperties.setPropertyNamed(buttonModel, "transparent", true);
         let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
         assert.equal(styleProp['visibility'], 'hidden');
     });
@@ -124,10 +130,10 @@ describe('Styling Properties', () => {
         };
         buttonModel.sendMessage(msg, buttonModel);
         let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
-        assert.equal(styleProp['visibility'], 'visible');
+        assert.equal(styleProp['display'], 'initial');
     });
     it('Updating StyleProperty via "set" updates the DOM element style attribute', () => {
         let buttonView = window.System.findViewById(buttonModel.id);
-        assert.equal(buttonView.style['visibility'], 'visible');
+        assert.equal(buttonView.style['display'], 'initial');
     });
 });

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -16,28 +16,36 @@ describe('CSS Styler Util', () => {
     before(() => {
         stylerObj = {};
     });
-    it('Text styles conversion', () => {
-        cssStyler(stylerObj, "text-color", "red");
-        assert.equal(stylerObj["color"], "red");
-        cssStyler(stylerObj, "font", "Times");
-        assert.equal(stylerObj["fontFamily"], "Times");
-    });
-    it('Name visibility', () => {
-        cssStyler(stylerObj, "name-visible", true);
-        assert.equal(stylerObj["color"], "initial");
-        cssStyler(stylerObj, "name-visible", false);
-        assert.equal(stylerObj["color"], "transparent");
+    describe('Text', () => {
+        it('Text font conversion', () => {
+            cssStyler(stylerObj, "text-font", "Times");
+            assert.equal(stylerObj["fontFamily"], "Times");
+        });
+        it('Text color conversion', () => {
+            cssStyler(stylerObj, "text-color", "rgb(255, 0, 0)");
+            assert.equal(stylerObj["color"], "rgba(255, 0, 0, 1)");
+            cssStyler(stylerObj, "text-color", "rgba(255, 0, 0, 1)");
+            assert.equal(stylerObj["color"], "rgba(255, 0, 0, 1)");
+            cssStyler(stylerObj, "text-color", "red");
+            assert.equal(stylerObj["color"], "rgba(255, 0, 0, 1)");
+        });
+        it('Text transparency', () => {
+            cssStyler(stylerObj, "text-transparency", .5);
+            assert.equal(stylerObj["color"], "rgba(255, 0, 0, 0.5)");
+            cssStyler(stylerObj, "text-transparency", ".5");
+            assert.equal(stylerObj["color"], "rgba(255, 0, 0, .5)");
+        });
     });
     it('Transparency', () => {
-        cssStyler(stylerObj, "transparent", false);
-        assert.equal(stylerObj["visibility"], "visible");
-        cssStyler(stylerObj, "transparent", true);
-        assert.equal(stylerObj["visibility"], "hidden");
+        cssStyler(stylerObj, "transparency", 0.5);
+        assert.equal(stylerObj["opacity"], 0.5);
+        cssStyler(stylerObj, "transparency", "0.5");
+        assert.equal(stylerObj["opacity"], "0.5");
     });
-    it('Visibility', () => {
-        cssStyler(stylerObj, "visible", true);
+    it('Hide', () => {
+        cssStyler(stylerObj, "hide", false);
         assert.equal(stylerObj["display"], "initial");
-        cssStyler(stylerObj, "visible", false);
+        cssStyler(stylerObj, "hide", true);
         assert.equal(stylerObj["display"], "none");
     });
     it('Background Color style conversion', () => {
@@ -72,7 +80,7 @@ describe('CSS Styler Util', () => {
         cssStyler(stylerObj, "background-color", "black");
         assert.equal(stylerObj["backgroundColor"], "black");
         cssStyler(stylerObj, "text-color", "black");
-        assert.equal(stylerObj["color"], "black");
+        assert.equal(stylerObj["color"], "rgba(0, 0, 0, 1)");
     });
 });
 
@@ -103,36 +111,36 @@ describe('Styling Properties', () => {
         // Note we just test for some of the core style props as the
         // complete list is likely to change in the future
         let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
-        assert.equal(styleProp['visibility'], 'visible');
+        assert.equal(styleProp['opacity'], 1.0);
         assert.equal(styleProp['textAlign'], 'center');
     });
     it('Initial button DOM element style attribute is properly set', () => {
         // Note we just test for some of the core style props as the
         // complete list is likely to change in the future
         let buttonView = window.System.findViewById(buttonModel.id);
-        assert.equal(buttonView.style['visibility'], 'visible');
+        assert.equal(buttonView.style['opacity'], 1.0);
         assert.equal(buttonView.style['textAlign'], 'center');
     });
     it('Updating StyleProperty directly updates the style property value', () => {
-        let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "visible");
-        assert.equal(styleProp, true);
-        buttonModel.partProperties.setPropertyNamed(buttonModel, "visible", false);
-        styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "visible");
+        let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "hide");
         assert.equal(styleProp, false);
+        buttonModel.partProperties.setPropertyNamed(buttonModel, "hide", true);
+        styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "hide");
+        assert.equal(styleProp, true);
     });
     it('Updating StyleProperty directly updates the "cssStyle" BasicProperty', () => {
         let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");
-        assert.equal(styleProp['visibility'], 'hidden');
+        assert.equal(styleProp['display'], 'none');
     });
     it('Updating StyleProperty directly updates the DOM element style attribute', () => {
         let buttonView = window.System.findViewById(buttonModel.id);
-        assert.equal(buttonView.style['visibility'], 'hidden');
+        assert.equal(buttonView.style['display'], 'none');
     });
     it('Updating StyleProperty via "set" message updates the "cssStyle" BasicProperty', () => {
         let msg  = {
             type: "command",
             commandName: "setProperty",
-            args: ["visible", true]
+            args: ["hide", false]
         };
         buttonModel.sendMessage(msg, buttonModel);
         let styleProp = buttonModel.partProperties.getPropertyNamed(buttonModel, "cssStyle");

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -18,6 +18,11 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         _setOrNot(styleObj, "backgroundColor",  propertyValue);
         break;
 
+    case "background-transparency":
+        // here we set the Alpha value of the current styleObj["backgroundColor"] rgba
+        _setOrNot(styleObj, "backgroundColor",  _colorToRGBA(styleObj["backgroundColor"], propertyValue));
+        break;
+
     case "text-color":
         _setOrNot(styleObj, "color",  _colorToRGBA(propertyValue));
         break;

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -15,7 +15,7 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
     switch(propertyName){
 
     case "background-color":
-        _setOrNot(styleObj, "backgroundColor",  propertyValue);
+        _setOrNot(styleObj, "backgroundColor",  _colorToRGBA(propertyValue));
         break;
 
     case "background-transparency":

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -58,12 +58,20 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         }
         break;
 
-    case "visible":
+    case "transparent":
         // TODO should this really be using the 'display' css prop
-        if(propertyValue === false){
+        if(propertyValue === true){
             styleObj["visibility"] = "hidden";
-        } else if(propertyValue === true){
+        } else if(propertyValue === false){
             styleObj["visibility"] = "visible";
+        }
+        break;
+
+    case "visible":
+        if(propertyValue === false){
+            styleObj["display"] = "none";
+        } else if(propertyValue === true){
+            styleObj["display"] = "initial";
         }
         break;
 

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -19,10 +19,10 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         break;
 
     case "text-color":
-        _setOrNot(styleObj, "color",  propertyValue);
+        _setOrNot(styleObj, "color",  _colorToRGBA(propertyValue));
         break;
 
-    case "font":
+    case "text-font":
         _setOrNot(styleObj, "fontFamily",  propertyValue);
         break;
 
@@ -32,6 +32,11 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
 
     case "text-align":
         _setOrNot(styleObj, "textAlign",  propertyValue);
+        break;
+
+    case "text-transparency":
+        // here we set the Alpha value of the current styleObj["color"] rgba
+        _setOrNot(styleObj, "color",  _colorToRGBA(styleObj["color"], propertyValue));
         break;
 
     case "top":
@@ -50,27 +55,14 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
         _setOrNot(styleObj, "transform",  _intToRotateDeg(propertyValue));
         break;
 
-    case "name-visible":
-        if(propertyValue === false){
-            styleObj["color"] = "transparent";
-        } else {
-            styleObj["color"] = "initial";
-        }
+    case "transparency":
+        _setOrNot(styleObj, "opacity",  propertyValue);
         break;
 
-    case "transparent":
-        // TODO should this really be using the 'display' css prop
+    case "hide":
         if(propertyValue === true){
-            styleObj["visibility"] = "hidden";
-        } else if(propertyValue === false){
-            styleObj["visibility"] = "visible";
-        }
-        break;
-
-    case "visible":
-        if(propertyValue === false){
             styleObj["display"] = "none";
-        } else if(propertyValue === true){
+        } else if(propertyValue === false){
             styleObj["display"] = "initial";
         }
         break;
@@ -95,7 +87,7 @@ const _setOrNot = (styleObj, name, value) => {
     if(value !== null && value !== undefined){
         styleObj[name] = value;
     }
-}
+};
 
 const _intToRotateDeg = (n) => {
     if(n !== null && n !== undefined){
@@ -104,7 +96,7 @@ const _intToRotateDeg = (n) => {
         }
         return `rotate(${n}deg)`;
     }
-}
+};
 
 
 const _intToPx = (n) => {
@@ -114,7 +106,60 @@ const _intToPx = (n) => {
         }
         return `${n}px`;
     }
+};
+
+// Convert colors to rgba
+// If a color string is a referenced name from the list
+// below then use its RGB values. Else if the string is
+// of the form RGBA with A=1. If A is provided
+// convert and/or replace the current value of A with the
+// argument value.
+const _colorToRGBA = (color, A) => {
+    if(color == null || color === undefined){
+        return;
+    }
+    let r, g, b, a;
+    // either RGB or RGBA is accepted
+    if(color.startsWith("rgb")){
+        [r, g, b, a] = color.match(/\d+/g);
+    } else {
+        let colorInfo = basicCSSColors[color];
+        if(colorInfo){
+            r = colorInfo["r"];
+            g = colorInfo["g"];
+            b = colorInfo["b"];
+            a = colorInfo["a"];
+        } else {
+            return;
+        }
+    }
+    if(A){
+        a = A;
+    } else if(a === undefined){
+        a = 1;
+    }
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
 }
+
+// Add more colors as needed
+const basicCSSColors = {
+    black: {hex: "#000000", r: 0, g: 0, b: 0},
+		silver: {hex: "#C0C0C0", r: 192, g: 192, b: 192},
+		gray: {hex: "#808080", r: 128, g: 128, b: 128},
+		white: {hex: "#FFFFFF", r: 255, g: 255, b: 255},
+		maroon: {hex: "#800000", r: 128, g: 0, b: 0},
+		red: {hex: "#FF0000", r: 255, g: 0, b: 0},
+		purple: {hex: "#800080", r: 128, g: 0, b: 128},
+		fuchsia: {hex: "#FF00FF", r: 255, g: 0, b: 255},
+		green: {hex: "#008000", r: 0, g: 128, b: 0},
+		lime: {hex: "#00FF00", r: 0, g: 255, b: 0},
+		olive: {hex: "#808000", r: 128, g: 128, b: 0},
+		yellow: {hex: "#FFFF00", r: 255, g: 255, b: 0},
+		navy: {hex: "#000080", r: 0, g: 0, b: 128},
+		blue: {hex: "#0000FF", r: 0, g: 0, b: 255},
+		teal: {hex: "#008080", r: 0, g: 128, b: 128},
+		aqua: {hex: "#00FFFF", r: 0, g: 255, b: 255},
+};
 
 export {
     cssStyler,

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -230,7 +230,7 @@ class FieldView extends PartView {
         this.toggleModePartProperty = this.toggleModePartProperty.bind(this);
         this.openColorWheelWidget = this.openColorWheelWidget.bind(this);
         this.onColorSelected = this.onColorSelected.bind(this);
-        this.onTransparencySlider = this.onTransparencySlider.bind(this);
+        this.onTransparencyChanged = this.onTransparencyChanged.bind(this);
 
         this.setupPropHandlers();
     }
@@ -362,7 +362,7 @@ class FieldView extends PartView {
         // colorWheelWidget event listener
         let colorWheel = this.shadowRoot.querySelector('color-wheel');
         colorWheel.addEventListener('color-selected', this.onColorSelected);
-        colorWheel.addEventListener('transparency-changed', this.onTransparencySlider);
+        colorWheel.addEventListener('transparency-changed', this.onTransparencyChanged);
     }
 
     onColorSelected(event){
@@ -376,7 +376,7 @@ class FieldView extends PartView {
         }, this.model);
     }
 
-    onTransparencySlider(event){
+    onTransparencyChanged(event){
         let command = event.target.getAttribute("selector-command");
         let propName = "transparency";
         // if the colorwheel is set to update the text-color

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -377,25 +377,17 @@ class FieldView extends PartView {
     }
 
     onTransparencyChanged(event){
-        let command = event.target.getAttribute("selector-command");
-        let propName = "transparency";
-        // if the colorwheel is set to update the text-color
-        // (as opposed background) then update the propName
-        // to "text-transparency"
-        if(command === "text-color"){
-            propName = "text-transparency";
-        }
         this.model.sendMessage({
             type: "command",
             commandName: "setProperty",
-            args: [propName, event.detail]
+            args: [event.detail.propName, event.detail.value]
         }, this.model);
     }
 
     // I set the selected editor mode, removing or adding corresponding
     // toolbard elements, as well as adding editor helpers/utilities.
     setEditorMode(mode){
-        let toolbarElementNames = ["insertorderedlist", "insertunorderedlist", "justifyleft", "justifycenter", "justifyright"];
+        let toolbarElementNames = ["insertunorderedlist", "justifyleft", "justifycenter", "justifyright"];
         let display = "inherit";
         this.editorCompleter = undefined;
         // spellcheck

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -350,6 +350,11 @@ class FieldView extends PartView {
 
     openColorWheelWidget(event, command){
         let colorWheelWidget = new ColorWheelWidget(command);
+        // we don't need the transparent and visible toggles on the color wheel
+        // if font color is selected
+        if(command === "color"){
+            colorWheelWidget.options = false;
+        };
         // add an attribute describing the command
         colorWheelWidget.setAttribute("selector-command", command);
         // add a custom callback for the close button

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -230,6 +230,8 @@ class FieldView extends PartView {
         this.toggleModePartProperty = this.toggleModePartProperty.bind(this);
         this.openColorWheelWidget = this.openColorWheelWidget.bind(this);
         this.onColorSelected = this.onColorSelected.bind(this);
+        this.onVisibleChecked = this.onVisibleChecked.bind(this);
+        this.onTransparentChecked = this.onTransparentChecked.bind(this);
 
         this.setupPropHandlers();
     }
@@ -359,6 +361,8 @@ class FieldView extends PartView {
         // colorWheelWidget event listener
         let colorWheel = this.shadowRoot.querySelector('color-wheel');
         colorWheel.addEventListener('color-selected', this.onColorSelected);
+        colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
+        colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
     }
 
     onColorSelected(event){
@@ -368,6 +372,22 @@ class FieldView extends PartView {
         // document.execCommand(command, false, colorStr);
         // TODO maybe this should be a partProperty
         this.textareaWrapper.style[command] = colorStr;
+    }
+
+    onVisibleChecked(event){
+        this.model.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["visible", event.detail]
+        }, this.model);
+    }
+
+    onTransparentChecked(event){
+        this.model.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["transparent", event.detail]
+        }, this.model);
     }
 
     // I set the selected editor mode, removing or adding corresponding

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -39,7 +39,6 @@ const templateString = `
 .field-textarea-wrapper {
     width: 100%;
     height: 100%;
-    background-color: var(--palette-cornsik);
     overflow: auto;
 }
 
@@ -63,6 +62,7 @@ const templateString = `
 .field-toolbar > * {
     margin-right: 2px;
     margin-left: 2px;
+    color: initial;
 }
 
 .field-toolbar > *:active {
@@ -177,7 +177,7 @@ const templateString = `
           <line x1="9.15" y1="14.85" x2="18" y2="4" />
           <line x1="6" y1="4" x2="14.85" y2="14.85" />
         </svg>
-        <svg id="field-color" xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-color-picker" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <svg id="field-textColor" xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-color-picker" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
           <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
           <line x1="11" y1="7" x2="17" y2="13" />
           <path d="M5 19v-4l9.7 -9.7a1 1 0 0 1 1.4 0l2.6 2.6a1 1 0 0 1 0 1.4l-9.7 9.7h-4" />
@@ -230,8 +230,7 @@ class FieldView extends PartView {
         this.toggleModePartProperty = this.toggleModePartProperty.bind(this);
         this.openColorWheelWidget = this.openColorWheelWidget.bind(this);
         this.onColorSelected = this.onColorSelected.bind(this);
-        this.onVisibleChecked = this.onVisibleChecked.bind(this);
-        this.onTransparentChecked = this.onTransparentChecked.bind(this);
+        this.onTransparencySlider = this.onTransparencySlider.bind(this);
 
         this.setupPropHandlers();
     }
@@ -322,8 +321,10 @@ class FieldView extends PartView {
             return true;
         } else if(["fontsize", "fontname"].indexOf(command) > -1){
             value = event.target.value;
-        } else if(["color", "backgroundColor"].indexOf(command) > -1){
-            this.openColorWheelWidget(event, command);
+        } else if(command === "textColor"){
+            this.openColorWheelWidget(event, "text-color");
+        } else if(command === "backgroundColor"){
+            this.openColorWheelWidget(event, "background-color");
         } else if(command === "mode"){
             this.setEditorMode(event.target.value);
             return true;
@@ -350,11 +351,6 @@ class FieldView extends PartView {
 
     openColorWheelWidget(event, command){
         let colorWheelWidget = new ColorWheelWidget(command);
-        // we don't need the transparent and visible toggles on the color wheel
-        // if font color is selected
-        if(command === "color"){
-            colorWheelWidget.options = false;
-        };
         // add an attribute describing the command
         colorWheelWidget.setAttribute("selector-command", command);
         // add a custom callback for the close button
@@ -366,32 +362,33 @@ class FieldView extends PartView {
         // colorWheelWidget event listener
         let colorWheel = this.shadowRoot.querySelector('color-wheel');
         colorWheel.addEventListener('color-selected', this.onColorSelected);
-        colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
-        colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
+        colorWheel.addEventListener('transparency-changed', this.onTransparencySlider);
     }
 
     onColorSelected(event){
         let command = event.target.getAttribute("selector-command");
         let colorInfo = event.detail;
         let colorStr = `rgba(${colorInfo.r}, ${colorInfo.g}, ${colorInfo.b}, ${colorInfo.alpha})`;
-        // document.execCommand(command, false, colorStr);
-        // TODO maybe this should be a partProperty
-        this.textareaWrapper.style[command] = colorStr;
-    }
-
-    onVisibleChecked(event){
         this.model.sendMessage({
             type: "command",
             commandName: "setProperty",
-            args: ["visible", event.detail]
+            args: [command, colorStr]
         }, this.model);
     }
 
-    onTransparentChecked(event){
+    onTransparencySlider(event){
+        let command = event.target.getAttribute("selector-command");
+        let propName = "transparency";
+        // if the colorwheel is set to update the text-color
+        // (as opposed background) then update the propName
+        // to "text-transparency"
+        if(command === "text-color"){
+            propName = "text-transparency";
+        }
         this.model.sendMessage({
             type: "command",
             commandName: "setProperty",
-            args: ["transparent", event.detail]
+            args: [propName, event.detail]
         }, this.model);
     }
 

--- a/js/objects/views/drawing/ColorPickerTool.js
+++ b/js/objects/views/drawing/ColorPickerTool.js
@@ -85,6 +85,7 @@ class ColorPickerTool extends HTMLElement {
         this.onMove = this.onMove.bind(this);
         this.toggleActive = this.toggleActive.bind(this);
         this.onColorSelected = this.onColorSelected.bind(this);
+        this.onTransparencyChanged = this.onTransparencyChanged.bind(this);
         this.setContextFromAttributes = this.setContextFromAttributes.bind(this);
     }
 
@@ -111,6 +112,7 @@ class ColorPickerTool extends HTMLElement {
             this.button.addEventListener('click', this.toggleActive);
             this.colorWheel = this.shadowRoot.querySelector('color-wheel');
             this.colorWheel.addEventListener('color-selected', this.onColorSelected);
+            this.colorWheel.addEventListener('transparency-changed', this.onTransparencyChanged);
         }
     }
 
@@ -118,6 +120,7 @@ class ColorPickerTool extends HTMLElement {
         this.ctx = null;
         this.button.removeEventListener('click', this.toggleActive);
         this.colorWheel.removeEventListener('color-selected', this.onColorSelected);
+        this.colorWheel.removeEventListener('transparency-changed', this.onTransparencyChanged);
     }
 
     start(x, y){
@@ -143,7 +146,13 @@ class ColorPickerTool extends HTMLElement {
         this.ctx.fillStyle = colorStr;
     }
 
-
+    onTransparencyChanged(event){
+        this.parentElement.model.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["transparency", event.detail]
+        }, this.parentElement.model);
+    }
 
     toggleActive(event){
         let isActive = this.getAttribute('active');

--- a/js/objects/views/drawing/ColorPickerTool.js
+++ b/js/objects/views/drawing/ColorPickerTool.js
@@ -143,6 +143,8 @@ class ColorPickerTool extends HTMLElement {
         this.ctx.fillStyle = colorStr;
     }
 
+
+
     toggleActive(event){
         let isActive = this.getAttribute('active');
         if(isActive == "true"){

--- a/js/objects/views/drawing/ColorWheelWidget.js
+++ b/js/objects/views/drawing/ColorWheelWidget.js
@@ -58,6 +58,18 @@ const colorWheelTemplate = `
     width: 100%;
     height: 25px;
   }
+  #options {
+    display: flex;
+    width: 100%;
+    height: 25px;
+    margin-top: 5px;
+  }
+
+  #options > label{
+    font-size: .8rem;
+    display: flex;
+    align-items: center;
+  }
 
   #recent-colors {
     display: flex;
@@ -85,6 +97,12 @@ const colorWheelTemplate = `
 <div id="palette-wrapper">
   <div id="palette-bar"><div id="close-button">x</div><span id="palette-title"></span></div>
   <div id="palette-content">
+    <div id="options">
+      <input type="checkbox" id="transparent" name="transparent">
+      <label for="transparent">Transparent</label>
+      <input type="checkbox" id="visible" name="visible" checked>
+      <label for="visible">Visible</label>
+    </div>
     <ul id="recent-colors">
       <li class="recent-color-item selected"></li>
       <li class="recent-color-item"></li>
@@ -120,6 +138,9 @@ class ColorWheelWidget extends HTMLElement {
         this.onBarMouseUp = this.onBarMouseUp.bind(this);
         this.onBarMouseMove = this.onBarMouseMove.bind(this);
         this.onClose = this.onClose.bind(this);
+        this.onTransparentChange = this.onTransparentChange.bind(this);
+        this.onVisibleChange = this.onVisibleChange.bind(this);
+        // this.onMakeTransparent = this.onMakeTransparent.bind(this);
         this._drawWheel = this._drawWheel.bind(this);
     }
 
@@ -127,6 +148,8 @@ class ColorWheelWidget extends HTMLElement {
         if(this.isConnected){
             this.canvas = this.shadowRoot.querySelector('canvas');
             this.bar = this.shadowRoot.getElementById('palette-bar');
+            this.visibleCheckbox = this.shadowRoot.getElementById('visible');
+            this.transparentCheckbox = this.shadowRoot.getElementById('transparent');
             // give the widget a title if provided
             if(this.name){
                 this.shadowRoot.getElementById('palette-title').innerText = this.name;
@@ -139,6 +162,8 @@ class ColorWheelWidget extends HTMLElement {
             Array.from(this.shadowRoot.querySelectorAll('.recent-color-item')).forEach(el => {
                 el.addEventListener('click', this.onItemClick);
             });
+            this.visibleCheckbox.addEventListener("change", this.onVisibleChange);
+            this.transparentCheckbox.addEventListener("change", this.onTransparentChange);
 
             // Draw the color wheel to the canvas
             this._drawWheel();
@@ -152,6 +177,8 @@ class ColorWheelWidget extends HTMLElement {
         Array.from(this.shadowRoot.querySelector('.recent-color-item')).forEach(el => {
             el.removeEventListener('click', this.onItemClick);
         });
+        this.visibleCheckbox.RemoveEventListener("change", this.onVisibleChange);
+        this.transparentCheckbox.RemoveEventListener("change", this.onTransparentChange);
     }
 
 
@@ -214,6 +241,19 @@ class ColorWheelWidget extends HTMLElement {
             currentSwatchSelection.style.backgroundColor = `rgba(${colorInfo.r}, ${colorInfo.g}, ${colorInfo.b}, ${colorInfo.alpha})`;
             currentSwatchSelection.selectedColor = colorInfo;
         }
+    }
+    onVisibleChange(event){
+        let newEvent = new CustomEvent('visible-checked', {
+            detail: event.target.checked 
+        });
+        this.dispatchEvent(newEvent);
+    }
+
+    onTransparentChange(event){
+        let newEvent = new CustomEvent('transparent-checked', {
+            detail: event.target.checked
+        });
+        this.dispatchEvent(newEvent);
     }
 
     onItemClick(event){

--- a/js/objects/views/drawing/ColorWheelWidget.js
+++ b/js/objects/views/drawing/ColorWheelWidget.js
@@ -239,8 +239,16 @@ class ColorWheelWidget extends HTMLElement {
     }
 
     onTransparencyChange(event){
+        let command = this.getAttribute("selector-command");
+        // update the corresponding transparency - text or background
+        // depending on what this color wheel is setup to update
+        let propName = "background-transparency";
+        if(command === "text-color"){
+            propName = "text-transparency";
+        }
+        let eventDetail = {propName: propName, value: event.target.value};
         let newEvent = new CustomEvent('transparency-changed', {
-            detail: event.target.value,
+            detail: eventDetail,
         });
         this.dispatchEvent(newEvent);
     }

--- a/js/objects/views/drawing/ColorWheelWidget.js
+++ b/js/objects/views/drawing/ColorWheelWidget.js
@@ -64,6 +64,7 @@ const colorWheelTemplate = `
     width: 100%;
     height: 25px;
     margin-top: 5px;
+    justify-content: center;
   }
 
   #options > label{
@@ -99,10 +100,8 @@ const colorWheelTemplate = `
   <div id="palette-bar"><div id="close-button">x</div><span id="palette-title"></span></div>
   <div id="palette-content">
     <div id="options">
-      <input type="checkbox" id="transparent" name="transparent">
-      <label for="transparent">Transparent</label>
-      <input type="checkbox" id="visible" name="visible" checked>
-      <label for="visible">Visible</label>
+      <input type="range" id="transparency" name="transparency" min="0" max="1" step="0.1" value="1">
+      <!-- <label for="transparency">Transparency</label>-->
     </div>
     <ul id="recent-colors">
       <li class="recent-color-item selected"></li>
@@ -120,7 +119,6 @@ class ColorWheelWidget extends HTMLElement {
         super();
 
         this.name = name;
-        this.options = true;
 
         // Setup shadow dom and template
         this.template = document.createElement('template');
@@ -140,9 +138,7 @@ class ColorWheelWidget extends HTMLElement {
         this.onBarMouseUp = this.onBarMouseUp.bind(this);
         this.onBarMouseMove = this.onBarMouseMove.bind(this);
         this.onClose = this.onClose.bind(this);
-        this.onTransparentChange = this.onTransparentChange.bind(this);
-        this.onVisibleChange = this.onVisibleChange.bind(this);
-        // this.onMakeTransparent = this.onMakeTransparent.bind(this);
+        this.onTransparencyChange = this.onTransparencyChange.bind(this);
         this._drawWheel = this._drawWheel.bind(this);
     }
 
@@ -162,15 +158,8 @@ class ColorWheelWidget extends HTMLElement {
             Array.from(this.shadowRoot.querySelectorAll('.recent-color-item')).forEach(el => {
                 el.addEventListener('click', this.onItemClick);
             });
-            // if the options are set to true display them
-            if(this.options){
-                this.visibleCheckbox = this.shadowRoot.getElementById('visible');
-                this.transparentCheckbox = this.shadowRoot.getElementById('transparent');
-                this.visibleCheckbox.addEventListener("change", this.onVisibleChange);
-                this.transparentCheckbox.addEventListener("change", this.onTransparentChange);
-            } else {
-                this.shadowRoot.getElementById('options').style.display = 'none';
-            }
+            this.transparencySlider = this.shadowRoot.getElementById('transparency');
+            this.transparencySlider.addEventListener("input", this.onTransparencyChange);
 
             // Draw the color wheel to the canvas
             this._drawWheel();
@@ -184,10 +173,7 @@ class ColorWheelWidget extends HTMLElement {
         Array.from(this.shadowRoot.querySelector('.recent-color-item')).forEach(el => {
             el.removeEventListener('click', this.onItemClick);
         });
-        if(this.options){
-            this.visibleCheckbox.removeEventListener("change", this.onVisibleChange);
-            this.transparentCheckbox.removeEventListener("change", this.onTransparentChange);
-        }
+        this.transparencySlider.removeEventListener("change", this.onTransparencyChange);
     }
 
 
@@ -251,16 +237,10 @@ class ColorWheelWidget extends HTMLElement {
             currentSwatchSelection.selectedColor = colorInfo;
         }
     }
-    onVisibleChange(event){
-        let newEvent = new CustomEvent('visible-checked', {
-            detail: event.target.checked 
-        });
-        this.dispatchEvent(newEvent);
-    }
 
-    onTransparentChange(event){
-        let newEvent = new CustomEvent('transparent-checked', {
-            detail: event.target.checked
+    onTransparencyChange(event){
+        let newEvent = new CustomEvent('transparency-changed', {
+            detail: event.target.value,
         });
         this.dispatchEvent(newEvent);
     }

--- a/js/objects/views/drawing/ColorWheelWidget.js
+++ b/js/objects/views/drawing/ColorWheelWidget.js
@@ -13,7 +13,8 @@
 const colorWheelTemplate = `
 <style>
   :host {
-    display: flex;
+    display: initial !important;
+    visibility: visible !important;
     position: relative;
     flex-direction: column;
     align-items: center;
@@ -119,6 +120,7 @@ class ColorWheelWidget extends HTMLElement {
         super();
 
         this.name = name;
+        this.options = true;
 
         // Setup shadow dom and template
         this.template = document.createElement('template');
@@ -148,8 +150,6 @@ class ColorWheelWidget extends HTMLElement {
         if(this.isConnected){
             this.canvas = this.shadowRoot.querySelector('canvas');
             this.bar = this.shadowRoot.getElementById('palette-bar');
-            this.visibleCheckbox = this.shadowRoot.getElementById('visible');
-            this.transparentCheckbox = this.shadowRoot.getElementById('transparent');
             // give the widget a title if provided
             if(this.name){
                 this.shadowRoot.getElementById('palette-title').innerText = this.name;
@@ -162,8 +162,15 @@ class ColorWheelWidget extends HTMLElement {
             Array.from(this.shadowRoot.querySelectorAll('.recent-color-item')).forEach(el => {
                 el.addEventListener('click', this.onItemClick);
             });
-            this.visibleCheckbox.addEventListener("change", this.onVisibleChange);
-            this.transparentCheckbox.addEventListener("change", this.onTransparentChange);
+            // if the options are set to true display them
+            if(this.options){
+                this.visibleCheckbox = this.shadowRoot.getElementById('visible');
+                this.transparentCheckbox = this.shadowRoot.getElementById('transparent');
+                this.visibleCheckbox.addEventListener("change", this.onVisibleChange);
+                this.transparentCheckbox.addEventListener("change", this.onTransparentChange);
+            } else {
+                this.shadowRoot.getElementById('options').style.display = 'none';
+            }
 
             // Draw the color wheel to the canvas
             this._drawWheel();
@@ -177,8 +184,10 @@ class ColorWheelWidget extends HTMLElement {
         Array.from(this.shadowRoot.querySelector('.recent-color-item')).forEach(el => {
             el.removeEventListener('click', this.onItemClick);
         });
-        this.visibleCheckbox.RemoveEventListener("change", this.onVisibleChange);
-        this.transparentCheckbox.RemoveEventListener("change", this.onTransparentChange);
+        if(this.options){
+            this.visibleCheckbox.removeEventListener("change", this.onVisibleChange);
+            this.transparentCheckbox.removeEventListener("change", this.onTransparentChange);
+        }
     }
 
 

--- a/js/objects/views/drawing/DrawingView.js
+++ b/js/objects/views/drawing/DrawingView.js
@@ -68,8 +68,6 @@ class DrawingView extends PartView {
         this.onMouseLeave = this.onMouseLeave.bind(this);
         this.onHaloResize = this.onHaloResize.bind(this);
         this.onClick = this.onClick.bind(this);
-        this.onTransparentChecked = this.onTransparentChecked.bind(this);
-        this.onVisibleChecked = this.onVisibleChecked.bind(this);
         this.initCustomHaloButton = this.initCustomHaloButton.bind(this);
         this.toggleMode = this.toggleMode.bind(this);
         this.afterDrawAction = this.afterDrawAction.bind(this);
@@ -123,8 +121,6 @@ class DrawingView extends PartView {
             let newColorPicker = document.createElement('color-picker-tool');
             this.append(newColorPicker);
             this.colorPickerTool = newColorPicker;
-            this.colorPickerTool.colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
-            this.colorPickerTool.colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
         }
 
         if(!this.haloButton){
@@ -135,8 +131,6 @@ class DrawingView extends PartView {
     afterDisconnected(){
         this.canvas.removeEventListener('mouseup', this.onMouseUp);
         this.canvas.removeEventListener('mousedown', this.onMouseDown);
-        this.colorPickerTool.colorWheel.removeEventListener('visible-checked', this.onVisibleChecked);
-        this.colorPickerTool.colorWheel.removeEventListener('transparent-checked', this.onTransparentChecked);
         this.removeEventListener('click', this.onClick);
     }
 
@@ -328,22 +322,6 @@ class DrawingView extends PartView {
             'mode',
             nextMode
         );
-    }
-
-    onVisibleChecked(event){
-        this.model.sendMessage({
-            type: "command",
-            commandName: "setProperty",
-            args: ["visible", event.detail]
-        }, this.model);
-    }
-
-    onTransparentChecked(event){
-        this.model.sendMessage({
-            type: "command",
-            commandName: "setProperty",
-            args: ["transparent", event.detail]
-        }, this.model);
     }
 
     get inDrawingMode(){

--- a/js/objects/views/drawing/DrawingView.js
+++ b/js/objects/views/drawing/DrawingView.js
@@ -57,6 +57,8 @@ class DrawingView extends PartView {
             this.template.content.cloneNode(true)
         );
 
+        this.colorPickerTool = null;
+
         this.isCurrentlyDrawing = false;
 
         // Bind component methods
@@ -66,6 +68,8 @@ class DrawingView extends PartView {
         this.onMouseLeave = this.onMouseLeave.bind(this);
         this.onHaloResize = this.onHaloResize.bind(this);
         this.onClick = this.onClick.bind(this);
+        this.onTransparentChecked = this.onTransparentChecked.bind(this);
+        this.onVisibleChecked = this.onVisibleChecked.bind(this);
         this.initCustomHaloButton = this.initCustomHaloButton.bind(this);
         this.toggleMode = this.toggleMode.bind(this);
         this.afterDrawAction = this.afterDrawAction.bind(this);
@@ -118,6 +122,9 @@ class DrawingView extends PartView {
         if(!colorPickerChild){
             let newColorPicker = document.createElement('color-picker-tool');
             this.append(newColorPicker);
+            this.colorPickerTool = newColorPicker;
+            this.colorPickerTool.colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
+            this.colorPickerTool.colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
         }
 
         if(!this.haloButton){
@@ -128,6 +135,8 @@ class DrawingView extends PartView {
     afterDisconnected(){
         this.canvas.removeEventListener('mouseup', this.onMouseUp);
         this.canvas.removeEventListener('mousedown', this.onMouseDown);
+        this.colorPickerTool.colorWheel.removeEventListener('visible-checked', this.onVisibleChecked);
+        this.colorPickerTool.colorWheel.removeEventListener('transparent-checked', this.onTransparentChecked);
         this.removeEventListener('click', this.onClick);
     }
 
@@ -319,6 +328,22 @@ class DrawingView extends PartView {
             'mode',
             nextMode
         );
+    }
+
+    onVisibleChecked(event){
+        this.model.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["visible", event.detail]
+        }, this.model);
+    }
+
+    onTransparentChecked(event){
+        this.model.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["transparent", event.detail]
+        }, this.model);
     }
 
     get inDrawingMode(){

--- a/js/objects/views/drawing/DrawingView.js
+++ b/js/objects/views/drawing/DrawingView.js
@@ -119,7 +119,9 @@ class DrawingView extends PartView {
         let colorPickerChild = this.querySelector('color-picker-tool');
         if(!colorPickerChild){
             let newColorPicker = document.createElement('color-picker-tool');
+            // TODO this is a total hack since drawing does not work well with styles at the moment
             this.append(newColorPicker);
+            newColorPicker.colorWheel.shadowRoot.querySelector('div#options').style.display = "none";
             this.colorPickerTool = newColorPicker;
         }
 

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -142,7 +142,7 @@ class ButtonEditorView extends HTMLElement {
         // this.setupExpanderAreas = this.setupExpanderAreas.bind(this);
         this.openColorWheelWidget = this.openColorWheelWidget.bind(this);
         this.onColorSelected = this.onColorSelected.bind(this);
-        this.onTransparencySlider = this.onTransparencySlider.bind(this);
+        this.onTransparencyChanged = this.onTransparencyChanged.bind(this);
         this.onMouseDownInBar = this.onMouseDownInBar.bind(this);
         this.onMouseUpAfterDrag = this.onMouseUpAfterDrag.bind(this);
         this.onMouseMoveInBar = this.onMouseMoveInBar.bind(this);
@@ -264,7 +264,7 @@ class ButtonEditorView extends HTMLElement {
         // colorWheelWidget event listener
         let colorWheel = this.shadowRoot.querySelector('color-wheel');
         colorWheel.addEventListener('color-selected', this.onColorSelected);
-        colorWheel.addEventListener('transparency-changed', this.onTransparencySlider);
+        colorWheel.addEventListener('transparency-changed', this.onTransparencyChanged);
     }
 
     onColorSelected(event){
@@ -278,7 +278,7 @@ class ButtonEditorView extends HTMLElement {
         }, this.target);
     }
 
-    onTransparencySlider(event){
+    onTransparencyChanged(event){
         let command = event.target.getAttribute("selector-command");
         let propName = "transparency";
         // if the colorwheel is set to update the text-color

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -256,6 +256,9 @@ class ButtonEditorView extends HTMLElement {
         colorWheelWidget = new ColorWheelWidget(event.target.name);
         // add an attribute describing the command
         colorWheelWidget.setAttribute("selector-command", event.target.name);
+        if(event.target.name == 'text-color'){
+            colorWheelWidget.options = false;
+        }
         // add a custom callback for the close button
         let closeButton = colorWheelWidget.shadowRoot.querySelector('#close-button');
         closeButton.addEventListener('click', () => {colorWheelWidget.remove();});
@@ -265,8 +268,10 @@ class ButtonEditorView extends HTMLElement {
         // colorWheelWidget event listener
         let colorWheel = this.shadowRoot.querySelector('color-wheel');
         colorWheel.addEventListener('color-selected', this.onColorSelected);
-        colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
-        colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
+        if(event.target.name !== 'text-color'){
+            colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
+            colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
+        }
     }
 
     onColorSelected(event){

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -279,18 +279,10 @@ class ButtonEditorView extends HTMLElement {
     }
 
     onTransparencyChanged(event){
-        let command = event.target.getAttribute("selector-command");
-        let propName = "transparency";
-        // if the colorwheel is set to update the text-color
-        // (as opposed background) then update the propName
-        // to "text-transparency"
-        if(command === "text-color"){
-            propName = "text-transparency";
-        }
         this.target.sendMessage({
             type: "command",
             commandName: "setProperty",
-            args: [propName, event.detail]
+            args: [event.detail.propName, event.detail.value]
         }, this.target);
     }
 

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -142,8 +142,7 @@ class ButtonEditorView extends HTMLElement {
         // this.setupExpanderAreas = this.setupExpanderAreas.bind(this);
         this.openColorWheelWidget = this.openColorWheelWidget.bind(this);
         this.onColorSelected = this.onColorSelected.bind(this);
-        this.onVisibleChecked = this.onVisibleChecked.bind(this);
-        this.onTransparentChecked = this.onTransparentChecked.bind(this);
+        this.onTransparencySlider = this.onTransparencySlider.bind(this);
         this.onMouseDownInBar = this.onMouseDownInBar.bind(this);
         this.onMouseUpAfterDrag = this.onMouseUpAfterDrag.bind(this);
         this.onMouseMoveInBar = this.onMouseMoveInBar.bind(this);
@@ -256,9 +255,6 @@ class ButtonEditorView extends HTMLElement {
         colorWheelWidget = new ColorWheelWidget(event.target.name);
         // add an attribute describing the command
         colorWheelWidget.setAttribute("selector-command", event.target.name);
-        if(event.target.name == 'text-color'){
-            colorWheelWidget.options = false;
-        }
         // add a custom callback for the close button
         let closeButton = colorWheelWidget.shadowRoot.querySelector('#close-button');
         closeButton.addEventListener('click', () => {colorWheelWidget.remove();});
@@ -268,10 +264,7 @@ class ButtonEditorView extends HTMLElement {
         // colorWheelWidget event listener
         let colorWheel = this.shadowRoot.querySelector('color-wheel');
         colorWheel.addEventListener('color-selected', this.onColorSelected);
-        if(event.target.name !== 'text-color'){
-            colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
-            colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
-        }
+        colorWheel.addEventListener('transparency-changed', this.onTransparencySlider);
     }
 
     onColorSelected(event){
@@ -285,19 +278,19 @@ class ButtonEditorView extends HTMLElement {
         }, this.target);
     }
 
-    onVisibleChecked(event){
+    onTransparencySlider(event){
+        let command = event.target.getAttribute("selector-command");
+        let propName = "transparency";
+        // if the colorwheel is set to update the text-color
+        // (as opposed background) then update the propName
+        // to "text-transparency"
+        if(command === "text-color"){
+            propName = "text-transparency";
+        }
         this.target.sendMessage({
             type: "command",
             commandName: "setProperty",
-            args: ["visible", event.detail]
-        }, this.target);
-    }
-
-    onTransparentChecked(event){
-        this.target.sendMessage({
-            type: "command",
-            commandName: "setProperty",
-            args: ["transparent", event.detail]
+            args: [propName, event.detail]
         }, this.target);
     }
 

--- a/js/objects/views/editors/ButtonEditorView.js
+++ b/js/objects/views/editors/ButtonEditorView.js
@@ -142,6 +142,8 @@ class ButtonEditorView extends HTMLElement {
         // this.setupExpanderAreas = this.setupExpanderAreas.bind(this);
         this.openColorWheelWidget = this.openColorWheelWidget.bind(this);
         this.onColorSelected = this.onColorSelected.bind(this);
+        this.onVisibleChecked = this.onVisibleChecked.bind(this);
+        this.onTransparentChecked = this.onTransparentChecked.bind(this);
         this.onMouseDownInBar = this.onMouseDownInBar.bind(this);
         this.onMouseUpAfterDrag = this.onMouseUpAfterDrag.bind(this);
         this.onMouseMoveInBar = this.onMouseMoveInBar.bind(this);
@@ -263,6 +265,8 @@ class ButtonEditorView extends HTMLElement {
         // colorWheelWidget event listener
         let colorWheel = this.shadowRoot.querySelector('color-wheel');
         colorWheel.addEventListener('color-selected', this.onColorSelected);
+        colorWheel.addEventListener('visible-checked', this.onVisibleChecked);
+        colorWheel.addEventListener('transparent-checked', this.onTransparentChecked);
     }
 
     onColorSelected(event){
@@ -273,6 +277,22 @@ class ButtonEditorView extends HTMLElement {
             type: "command",
             commandName: "setProperty",
             args: [command, colorStr]
+        }, this.target);
+    }
+
+    onVisibleChecked(event){
+        this.target.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["visible", event.detail]
+        }, this.target);
+    }
+
+    onTransparentChecked(event){
+        this.target.sendMessage({
+            type: "command",
+            commandName: "setProperty",
+            args: ["transparent", event.detail]
         }, this.target);
     }
 


### PR DESCRIPTION
### Main Points ###

A simple setup for "transparent" and "visible" part properties. The properties and styler are fine and trivial to set up. 

I added these to the color-wheel (there is an [option](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-transparent?expand=1#diff-2433c8a1dcdb9e45dfd097ee0a4178a4d44f6a2f3f5f121f6f61b97644b962e9R166) to not include them). Since the color-wheel was set up to send custom events on color select, b/c it is not aware of its target, I decided to stick to the same framework. I don't think it's very good though and forces a lot more code than necessary. For example you need to write event handlers for each part-view that has a color wheel acting on it. 

I think better would be to create editors for each part that are fully aware of their target, like button editors, and have whatever widgets they use also be aware of the target and then simply send a message to the corresponding part property. 
Similarly drawing attributes like color, brush stroke etc should be part props on the drawing part-model and set accordingly. But that's for another PR. 

One thing to notice is that toggling the transparent checkbox can technically make the color-wheel also transparent. This is b/c the underlying cssStyler converts this property (if set to true) to `visibility:hidden` which is inherited by the color-wheel if it is setup as a DOM descendant of the target part-view. I got around this by forcing `visibility: visible` on the color-wheel: host. But the same can't be said for the "visible" property which at the moment sets `display: none` and that you can't get around. Of course you could use some other css mapping but that I don't think is the point. Probably best to remove editors from their respective views all-together. 