### PR TITLE
String Concatenation

### DIFF
--- a/js/objects/tests/test-string-concatenation-with-preload.js
+++ b/js/objects/tests/test-string-concatenation-with-preload.js
@@ -1,0 +1,64 @@
+import chai from 'chai';
+import ohm from 'ohm-js';
+const assert = chai.assert;
+const expect = chai.expect;
+
+import interpreterSemantics from '../../ohm/interpreter-semantics.js';
+
+let testLanguageGrammar = ohm.grammar(window.grammar);
+
+describe("String Concatenation Interpreter Tests", () => {
+    let semantics;
+    before(() => {
+        semantics = testLanguageGrammar.createSemantics();
+        semantics.addOperation(
+            'interpret',
+            interpreterSemantics(null, window.System)
+        );
+    });
+
+    it("Can concatenate two string literals", () => {
+        let input = `"Hello, " & "world!"`;
+        let expected = "Hello, world!";
+        let matchObject = testLanguageGrammar.match(input, "Expression");
+        assert.isTrue(matchObject.succeeded());
+        let result = semantics(matchObject).interpret();
+        assert.equal(expected, result);
+    });
+
+    it("Can concatenate an integer literal and a string literal", () => {
+        let input = `-2 & " times!"`;
+        let expected = "-2 times!";
+        let matchObject = testLanguageGrammar.match(input, "Expression");
+        assert.isTrue(matchObject.succeeded());
+        let result = semantics(matchObject).interpret();
+        assert.equal(expected, result);
+    });
+
+    it("Can concatenate two integer literals", () => {
+        let input = `-2 & 3`;
+        let expected = "-23";
+        let matchObject = testLanguageGrammar.match(input, "Expression");
+        assert.isTrue(matchObject.succeeded());
+        let result = semantics(matchObject).interpret();
+        assert.equal(expected, result);
+    });
+
+    it("Can concatenate an expression and a string literal", () => {
+        let input = `"Value is: " & (-1 * (5 + 2.01))`;
+        let expected = "Value is: -7.01";
+        let matchObject = testLanguageGrammar.match(input, "Expression");
+        assert.isTrue(matchObject.succeeded());
+        let result = semantics(matchObject).interpret();
+        assert.equal(expected, result);
+    });
+
+    it("Can concatenate a complex example (4 items)", () => {
+        let input = `"Hello, you have " & -2 & " items available and " & (2 + (3 * 4)) & " points!"`;
+        let expected = "Hello, you have -2 items available and 14 points!";
+        let matchObject = testLanguageGrammar.match(input, "Expression");
+        assert.isTrue(matchObject.succeeded());
+        let result = semantics(matchObject).interpret();
+        assert.equal(expected, result);
+    });
+});

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -300,6 +300,14 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             let second = secondExpression.interpret();
             return first * second;
         },
+
+        Expression_stringConcatExpr: function(firstExpression, operation, secondExpression){
+            // When we encounter the "&" operator, we coerce both expressions into
+            // a string
+            let first = firstExpression.interpret().toString();
+            let second = secondExpression.interpret().toString();
+            return `${first}${second}`;
+        },
         
         Factor_parenFactor: function(leftParen, expression, rightParen){
             return expression.interpret();

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -77,7 +77,8 @@
         Expression
                = Expression "+" Expression --addExpr
                | Expression "*" Expression --timesExpr
-			   | Expression "-" Expression --minusExpr
+	       | Expression "-" Expression --minusExpr
+               | Expression "&" Expression --stringConcatExpr
                | Factor
 
 
@@ -204,7 +205,7 @@
 		| "delete" "this"? systemObject objectId? --deleteModel
 		| "add" systemObject stringLiteral? "to"? ("this" | "current")? systemObject? objectId? --addModel
 		| "set" stringLiteral "to" (stringLiteral | variableName | integerLiteral ) InClause? --setProperty
-		| "put" Factor "into" "global"? variableName --putVariable
+		| "put" Expression "into" "global"? variableName --putVariable
 		| "ask" anyLiteral --ask
     | "tell" ObjectSpecifier "to" Command --tellCommand
 		| messageName CommandArgumentList? --arbitraryCommand

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -201,7 +201,7 @@
 	Command (a command statement)
 		= "go to" ("next" | "previous") systemObject --goToDirection
 		| "go to" systemObject objectId --goToByReference
-		| "answer" (stringLiteral | variableName) --answer
+		| "answer" Expression --answer
 		| "delete" "this"? systemObject objectId? --deleteModel
 		| "add" systemObject stringLiteral? "to"? ("this" | "current")? systemObject? objectId? --addModel
 		| "set" stringLiteral "to" (stringLiteral | variableName | integerLiteral ) InClause? --setProperty

--- a/js/ohm/tests/test-string-grammar.js
+++ b/js/ohm/tests/test-string-grammar.js
@@ -1,0 +1,96 @@
+/**
+ * String and stringLiteral
+ * related grammatical tests
+ **/
+ohm = require('ohm-js');
+// Instantiate the grammar.
+var fs = require('fs');
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+
+var chai = require('chai');
+var assert = chai.assert;
+
+const matchTest = (str) => {
+    const match = g.match(str);
+    assert.isTrue(match.succeeded());
+}
+const semanticMatchTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isTrue(typeMatch.succeeded());
+};
+
+const semanticMatchFailTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isFalse(typeMatch.succeeded());
+};
+
+describe("Basic stringLiteral", () => {
+    it('Can deal with a single word', () => {
+        const s = '"test"';
+        semanticMatchTest(s, 'stringLiteral');
+        semanticMatchTest(s, 'Factor');
+    });
+    it('Can deal with a sentence', () => {
+        const s = '"this is a test"';
+        semanticMatchTest(s, 'stringLiteral');
+        semanticMatchTest(s, 'Factor');
+    });
+    it('Can deal with a url', () => {
+        const s = '"http://localhost:8000/js/objects/examples/bootstrap-example.html"';
+        semanticMatchTest(s, 'stringLiteral');
+        semanticMatchTest(s, 'Factor');
+    });
+    it('Can deal with a path', () => {
+        const s = '"../../examples/bootstrap-example.html"';
+        semanticMatchTest(s, 'stringLiteral');
+        semanticMatchTest(s, 'Factor');
+    });
+    it('Can deal with whitespace', () => {
+        const s = '" \t   hi \t  \s  "';
+        semanticMatchTest(s, 'stringLiteral');
+        semanticMatchTest(s, 'Factor');
+    });
+    it('Can deal with characters that look like operators', () => {
+        const s = `"hello ** this / is ^ a stringLiteral +"`;
+        semanticMatchTest(s, 'stringLiteral');
+        semanticMatchTest(s, 'Factor');
+    });
+    it('Does not match if newline is present', () => {
+        const s = '"this is a\t\ntest"';
+        semanticMatchFailTest(s, 'stringLiteral');
+        semanticMatchFailTest(s, 'Factor');
+    });
+});
+
+describe("Concatenation Tests", () => {
+    it("Can concat two stringLiterals", () => {
+        let s = `"some first string" & "some second string"`;
+        semanticMatchTest(s, "Expression");
+        semanticMatchTest(s, "Expression_stringConcatExpr");
+    });
+    it("Can concat two stringLiterals containing & symbol", () => {
+        let s = `"& this is the string" & "this is another && string"`;
+        semanticMatchTest(s, "Expression");
+        semanticMatchTest(s, "Expression_stringConcatExpr");
+    });
+    it("Can concat a stringLiteral and a variableName", () => {
+        let s = `"This is the first part" & someStringVar`;
+        semanticMatchTest(s, "Expression");
+        semanticMatchTest(s, "Expression_stringConcatExpr");
+    });
+    it("Can concat a variableName and a stringLiteral", () => {
+        let s = `someStringVar & "This is a string"`;
+        semanticMatchTest(s, "Expression");
+        semanticMatchTest(s, "Expression_stringConcatExpr");
+    });
+    it("Can concat two variableNames", () => {
+        let s = `firstStringVar & secondStringVar`;
+        semanticMatchTest(s, "Expression");
+        semanticMatchTest(s, "Expression_stringConcatExpr");
+    });
+    it("Can concat several relevant rules at once", () => {
+        let s = `myStringVar & "This is a literal string" & anotherVar & "Some string with & symbol"`;
+        semanticMatchTest(s, "Expression");
+        semanticMatchTest(s, "Expression_stringConcatExpr");
+    });
+});


### PR DESCRIPTION
## What ##
This PR (finally!) implements a first pass at string concatenation.
  
## Implementation ##
You can concatenate any two Expressions using the `&` symbol. The expressions on either side of the symbol **will be coerced into strings** and concatenated into a resulting string. This has the advantage of easily turning numerical values into strings that can be displayed.
  
Because any variable is also a Factor, and any Factor is an Expression, you can concatenate variables as well. These will also be coerced into strings first.
  
## Examples ##
```simpletalk
on click
    answer "Hello, " & "world!"
end click
```

```simpletalk
on click
    put "world!" into mySuffix
    answer "Hello, " & mySuffix
end click
```

```simpletalk
on click
    answer "You clicked " & 2.4 & " times on average"
end click
```

```simpletalk
on click
    put 4 into numCycles
    answer "You clicked & (numCycles * 10) & " times"
end click
```
  
## Tests ##
I have added [grammar tests](https://github.com/UnitedLexCorp/SimpleTalk/blob/eric-string-concatenation/js/ohm/tests/test-string-grammar.js) and [preload/integration tests](https://github.com/UnitedLexCorp/SimpleTalk/blob/eric-string-concatenation/js/objects/tests/test-string-concatenation-with-preload.js).