### PR TITLE
Reading Property Values in Scripts

### DIFF
--- a/js/objects/tests/test-property-value-with-preload.js
+++ b/js/objects/tests/test-property-value-with-preload.js
@@ -1,0 +1,122 @@
+/**
+ * PropertyValue semantic rule tests
+ */
+import chai from 'chai';
+const assert = chai.assert;
+const expect = chai.expect;
+
+let currentCardModel;
+let buttonModel;
+
+function compileButtonScript(aScript){
+    let msg = {
+        type: 'compile',
+        codeString: aScript,
+        targetId: buttonModel.id
+    };
+    window.System.compile(msg);
+}
+
+describe("PropertyValue Interpreter Tests", () => {
+    describe('Model Setup', () => {
+        it('Can find the current card model', () => {
+            let currentCardView = document.querySelector('.current-stack > .current-card');
+            currentCardModel = currentCardView.model;
+            assert.exists(currentCardModel);
+        });
+        it('Can add a button to current card model without error', () => {
+            let addButton = function(){
+                let msg = {
+                    type: 'command',
+                    commandName: 'newModel',
+                    args: [
+                        'button',
+                        currentCardModel.id,
+                        'card'
+                    ]
+                };
+                currentCardModel.sendMessage(msg, currentCardModel);
+            };
+            expect(addButton).to.not.throw(Error);
+        });
+        it('Can find newly created button model', () => {
+            let button = currentCardModel.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            buttonModel = button;
+            assert.exists(buttonModel);
+        });
+    });
+    describe("PropertyValue lookup tests", () => {
+        before(() => {
+            currentCardModel.partProperties.setPropertyNamed(
+                currentCardModel,
+                'name',
+                'TEST_CARD'
+            );
+            buttonModel.partProperties.setPropertyNamed(
+                buttonModel,
+                'name',
+                'TEST_BUTTON'
+            );
+        });
+
+        it("Button can read implicit property value on itself", () => {
+            let script = [
+                'on click',
+                'put the "name" into global result',
+                'end click'
+            ].join('\n');
+            compileButtonScript(script);
+            buttonModel.sendMessage({type:'command', commandName:'click', args:[]}, buttonModel);
+            let result = window.System.executionStack.getGlobal('result');
+            assert.equal(result, 'TEST_BUTTON');
+        });
+        it("Button can read prop value using 'this button'", () => {
+            let script = [
+                'on click',
+                'put the "name" of this button into global result',
+                'end click'
+            ].join('\n');
+            compileButtonScript(script);
+            buttonModel.sendMessage({type:'command', commandName:'click', args:[]}, buttonModel);
+            let result = window.System.executionStack.getGlobal('result');
+            assert.equal(result, 'TEST_BUTTON');
+        });
+        it("Button should error when trying to read prop value using 'this field' (wrong part type)", () => {
+            let script = [
+                'on click',
+                'put the "name" of this field into global result',
+                'end click'
+            ].join('\n');
+            compileButtonScript(script);
+            let sendFunction = function(){
+                buttonModel.sendMessage({type:'command', commandName:'click', args:[]}, buttonModel);
+            };
+            expect(sendFunction).to.throw(Error);
+        });
+        it("Button should be able to get prop of parent card via specifier", () => {
+            let script = [
+                'on click',
+                'put the "name" of first card of current stack into global result',
+                'end click'
+            ].join('\n');
+            compileButtonScript(script);
+            buttonModel.sendMessage({type:'command', commandName:'click', args:[]}, buttonModel);
+            let result = window.System.executionStack.getGlobal('result');
+            assert.equal(result, 'TEST_CARD');
+        });
+        it("Button should be able to get prop of itself via long specifier", () => {
+            let script = [
+                'on click',
+                'put the "name" of first button of card 1 of current stack into global result',
+                'end click'
+            ].join('\n');
+            compileButtonScript(script);
+            buttonModel.sendMessage({type:'command', commandName:'click', args:[]}, buttonModel);
+            let result = window.System.executionStack.getGlobal('result');
+            assert.equal(result, 'TEST_BUTTON');
+        });
+        
+    });
+});

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -546,6 +546,9 @@ const createInterpreterSemantics = (partContext, systemContext) => {
         PropertyValue_withSpecifier: function(theLiteral, propName, ofLiteral, objectSpecifier){
             let targetId = objectSpecifier.interpret();
             let target = systemContext.partsById[targetId];
+            if(!target){
+                throw new Error(`Could not find part with id ${targetId} (${this.sourceString})`);
+            }
             return target.partProperties.getPropertyNamed(
                 target,
                 propName.interpret()
@@ -809,6 +812,11 @@ const createInterpreterSemantics = (partContext, systemContext) => {
                 finalPart = findNearestParentOfKind(partContext, 'card');
             }
             let result = partialSpecifier.interpret()(finalPart);
+            return result.id;
+        },
+
+        ObjectSpecifier_singleTerminal: function(terminalSpecifier){
+            let result = terminalSpecifier.interpret()(partContext);
             return result.id;
         },
 

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -543,6 +543,22 @@ const createInterpreterSemantics = (partContext, systemContext) => {
             return null;
         },
 
+        PropertyValue_withSpecifier: function(theLiteral, propName, ofLiteral, objectSpecifier){
+            let targetId = objectSpecifier.interpret();
+            let target = systemContext.partsById[targetId];
+            return target.partProperties.getPropertyNamed(
+                target,
+                propName.interpret()
+            );
+        },
+
+        PropertyValue_withoutSpecifier: function(theLiteral, propName){
+            return partContext.partProperties.getPropertyNamed(
+                partContext,
+                propName.interpret()
+            );
+        },
+
         /** Object Specifiers **/
 
         /**

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -66,6 +66,7 @@
         Factor (a factor)
                = "(" Expression ")" --parenFactor
                | "not" Expression --notFactor
+               | PropertyValue
                | anyLiteral
                | variableName
 
@@ -164,6 +165,12 @@
         CommandArgumentList
                 = NonemptyListOf<Expression, ",">
 
+
+        // Reading property values of parts is the same
+        // as asking for such value on an ObjectSpecifier
+        PropertyValue
+                = "the" propertyName "of" ObjectSpecifier --withSpecifier
+                | "the" propertyName --withoutSpecifier
 
         // A "terminal" specifier is one that cannot have
         // "of" attached to the end of it because it's the
@@ -284,6 +291,11 @@
 	// closing quotes
 	stringLiteral
 		= quoteMark (~lineTerminator ~quoteMark any)* quoteMark
+
+        // For now, a property name is wrapped in quotes, ie it
+        // is the same as a stringLiteral
+        propertyName
+                = stringLiteral
 
 	quoteMark = "\""
 

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -211,11 +211,11 @@
 		| "go to" systemObject objectId --goToByReference
 		| "answer" Expression --answer
 		| "delete" "this"? systemObject objectId? --deleteModel
-    | "set" Expression "to" Expression InClause? --setProperty
+                | "set" Expression "to" Expression InClause? --setProperty
 		| "add" systemObject stringLiteral? "to"? ObjectSpecifier --addModel
 		| "put" Expression "into" "global"? variableName --putVariable
 		| "ask" anyLiteral --ask
-    | "tell" ObjectSpecifier "to" Command --tellCommand
+                | "tell" ObjectSpecifier "to" Command --tellCommand
 		| messageName CommandArgumentList? --arbitraryCommand
 
 	CommentLines

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -211,7 +211,7 @@
 		| "go to" systemObject objectId --goToByReference
 		| "answer" Expression --answer
 		| "delete" "this"? systemObject objectId? --deleteModel
-                | "set" Expression "to" Expression InClause? --setProperty
+                | "set" propertyName "to" Expression InClause? --setProperty
 		| "add" systemObject stringLiteral? "to"? ObjectSpecifier --addModel
 		| "put" Expression "into" "global"? variableName --putVariable
 		| "ask" anyLiteral --ask

--- a/js/ohm/tests/test-property-value-grammar.js
+++ b/js/ohm/tests/test-property-value-grammar.js
@@ -1,0 +1,39 @@
+ohm = require('ohm-js');
+// Instantiate the grammar.
+var fs = require('fs');
+var g = ohm.grammar(fs.readFileSync('./js/ohm/simpletalk.ohm'));
+
+var chai = require('chai');
+var assert = chai.assert;
+
+const matchTest = (str) => {
+    const match = g.match(str);
+    assert.isTrue(match.succeeded());
+};
+const semanticMatchTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isTrue(typeMatch.succeeded());
+};
+
+const semanticMatchFailTest = (str, semanticType) => {
+    const typeMatch = g.match(str, semanticType);
+    assert.isFalse(typeMatch.succeeded());
+};
+
+describe("PropertyValue grammar tests", () => {
+    it("Can parse a PropertyValue with implicit context", () => {
+        let str = `the "name"`;
+        semanticMatchTest(str, "PropertyValue");
+        semanticMatchTest(str, "PropertyValue_withoutSpecifier");
+    });
+    it("Can match a PropertyValue with deep object specifier context", () => {
+        let str = `the "name" of field 3 of second card of current stack`;
+        semanticMatchTest(str, "PropertyValue");
+        semanticMatchTest(str, "PropertyValue_withSpecifier");
+    });
+    it("Can parse a PropertyValue with 'this <partType>' context", () => {
+        let str = `the "name" of this button`;
+        semanticMatchTest(str, "PropertyValue");
+        semanticMatchTest(str, "PropertyValue_withSpecifier");
+    });
+});

--- a/js/ohm/tests/test-property-value-grammar.js
+++ b/js/ohm/tests/test-property-value-grammar.js
@@ -36,4 +36,8 @@ describe("PropertyValue grammar tests", () => {
         semanticMatchTest(str, "PropertyValue");
         semanticMatchTest(str, "PropertyValue_withSpecifier");
     });
+    it("Can parse a PropertyValue as a part of a Factored Expression", () => {
+        let str = `(the "top" of this card + 5)`;
+        semanticMatchTest(str, "Expression");
+    });
 });


### PR DESCRIPTION
## What ##
This PR implements a first pass at allowing users to read and use Part Property values in scripts. This ability did not exist until now -- we could set property values, but not "read" them.
  
## Implementation ##
The grammar change is simple enough. The pattern is, generally, `the "<propName>" of <ObjectSpecifier>`. There is an alternate form where you can drop the `of <ObjectSpecifier>` portion and the Part will implicitly be the one invoking the script handler.
 
Note also that this new rule `PropertyValue`, is also a `Factor`, meaning it can be used in Expressions or any other rule that can accept expressions.
 
## Examples ##
```simpletalk
on click
    -- Answer the "name" property value of the button
    answer the "name"
    -- Also answer the "name" property value of the button,
    -- but using a specifier
    answer the "name" of this button
    -- And again, but even more roundabout
    answer the "name" of button 2 of third card of current stack
    -- Add to a property and set it again all in one line
    -- (will work after rebase)
    set the "top" of this button to (the "top" of this button + 5)
end click
```
  
## Tests ##
There are grammar and integration tests