### PR TITLE
command prop changed

### DIFF
--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -376,14 +376,17 @@ class Part {
             var result = boundHandler(aMessage.senders, ...aMessage.args);
             window.System.executionStack.pop();
             return result;
-            
         }
 
         // Otherwise, we have no handler for
-        // it, so we delegate along the
+        // it. Unless the message indicates shouldNotDelegate
+        // we delegate along the
         // message delegation chain. It is up
         // to Parts to properly implement delegation
         // for themselves!
+        if(aMessage.shouldNotDelegate){
+            return aMessage;
+        }
         return this.delegateMessage(aMessage);
     }
 

--- a/js/objects/properties/PartProperties.js
+++ b/js/objects/properties/PartProperties.js
@@ -136,6 +136,12 @@ class StyleProperty extends BasicProperty {
 
             // set my value as well
             this._value = val;
+            if(notify){
+                owner.propertyChanged(
+                    this.name,
+                    val
+                );
+            }
         }
     }
 };

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -147,10 +147,15 @@ class PartView extends HTMLElement {
     }
 
     primHandlePropChange(name, value, partId){
+        // We notify the model that the property change so that
+        // on propertyChanged command handlers could be invoked
+        // but we make sure that this stops at the said model and
+        // does not go up the delegation chain
         let commandMessage = {
             type: 'command',
             commandName: 'propertyChanged',
             args: [name, value],
+            shouldNotDelegate:true, // do not send this up the delegation chain
             shouldIgnore: true
         };
         this.sendMessage(commandMessage, this.model);

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -147,6 +147,13 @@ class PartView extends HTMLElement {
     }
 
     primHandlePropChange(name, value, partId){
+        let commandMessage = {
+            type: 'command',
+            commandName: 'propertyChanged',
+            args: [name, value],
+            shouldIgnore: true
+        };
+        this.sendMessage(commandMessage, this.model);
         // Find the handler for the given named
         // property. If it does not exist, do nothing
         let handler = this.propChangeHandlers[name];

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -204,9 +204,9 @@
 		| "go to" systemObject objectId --goToByReference
 		| "answer" Expression --answer
 		| "delete" "this"? systemObject objectId? --deleteModel
-		| "add" systemObject stringLiteral? "to"? ObjectSpecifier --addModel
+		| "add" systemObject stringLiteral? "to"? ("this" | "current")? systemObject? objectId? --addModel
+		| "set" (stringLiteral | variableName) "to" (stringLiteral | variableName | integerLiteral ) InClause? --setProperty
 		| "put" Expression "into" "global"? variableName --putVariable
-		| "set" stringLiteral "to" (anyLiteral | variableName ) InClause? --setProperty
 		| "ask" anyLiteral --ask
     | "tell" ObjectSpecifier "to" Command --tellCommand
 		| messageName CommandArgumentList? --arbitraryCommand

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -204,8 +204,8 @@
 		| "go to" systemObject objectId --goToByReference
 		| "answer" Expression --answer
 		| "delete" "this"? systemObject objectId? --deleteModel
-		| "add" systemObject stringLiteral? "to"? ("this" | "current")? systemObject? objectId? --addModel
-		| "set" (stringLiteral | variableName) "to" (stringLiteral | variableName | integerLiteral ) InClause? --setProperty
+    | "set" Expression "to" Expression InClause? --setProperty
+		| "add" systemObject stringLiteral? "to"? ObjectSpecifier --addModel
 		| "put" Expression "into" "global"? variableName --putVariable
 		| "ask" anyLiteral --ask
     | "tell" ObjectSpecifier "to" Command --tellCommand

--- a/js/ohm/tests/test-grammar.js
+++ b/js/ohm/tests/test-grammar.js
@@ -539,10 +539,6 @@ describe("SimpleTalk Grammar", () => {
                     });
                 });
             });
-            it ("Bad construction (no quotes)", () => {
-                const s = `set backgroundColor to "blue" in card 10`;
-                semanticMatchFailTest(s, "Command");
-            });
         });
         describe("Arbitrary", () => {
             it ("arbitrary command", () => {


### PR DESCRIPTION
### Main Points ###

After a view receives a `propertyChanged` type message it will [send](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-command-propChanged?expand=1#diff-f8a644f39713f7d56b51b944769a8733fceb081884704c2a73b93c232b554560R150) a type `command` `propertyChanged` message to its model/part. This message is set not to delegate, which is a new option for messages handled [here](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-command-propChanged?expand=1#diff-efd61be9944474fec7ba0b89d7a931fedae606964b569ff27b2766271c5244b9R387). 

Note: the `propertyChanged` command is sent **regardless** of whether the view subscribes to the property being changed. This is necessary because a given property might (dynamically) alter another property which the view subscribes to. Our StyleProps are a good example. This allows a separation + translation layer between SimpleTalk and whatever is necessary to property render the thing. For example, "text-color" is a SimpleTalk property but it's corresponding CSS is "color" which is set by the `cssStyler` in the `cssStyle` property. The latter is what a view actually subscribes to. 

Anyhow the changes here are all pretty simple and I've added tests. 

++ 
Fun example:

![image](https://user-images.githubusercontent.com/1154326/109341289-80573f00-786a-11eb-8721-104ded91c4a3.png)

script for button "Controller"
```
on propertyChanged name, value
   if name == "background-color" then setTarget name, value
   if name == "left" then setTarget name, value
   if name == "text-color" then loadImage
end propertyChanged

on setTarget name, value
   set name to value in button "Target"
end setTarget 

on loadImage
   tell first image of current card to loadImageFrom "https://source.unsplash.com/random"
end loadImage
```


