### PR TITLE
Serialization IDs

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -1401,15 +1401,15 @@ System._commandHandlers['openDebugger'] = function(senders, partId){
 
 System._commandHandlers['saveHTML'] = function(senders){
     this.serialize();
-    
-    let anchor = document.createElement('a');
-    anchor.style.display = "none";
-    document.body.append(anchor);
 
     let stamp = Date.now().toString();
     let serializedPage = this.getFullHTMLString();
     let typeInfo = "data:text/plain;charset=utf-8";
     let url = `${typeInfo},${encodeURIComponent(serializedPage)}`;
+
+    let anchor = document.createElement('a');
+    anchor.style.display = "none";
+    document.body.append(anchor);
     anchor.href = url;
     anchor.download = `SimpleTalkSnapshot_${stamp}.html`;
     anchor.click();

--- a/js/objects/examples/bootstrap.html
+++ b/js/objects/examples/bootstrap.html
@@ -1,4 +1,5 @@
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml"><head>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
     <meta charset="utf-8" />
     <title>System Object Example</title>
     <link rel="stylesheet" href="../../../css/core.css" />

--- a/js/objects/parts/Window.js
+++ b/js/objects/parts/Window.js
@@ -136,7 +136,18 @@ class Window extends Part {
     get type(){
         return 'window';
     }
-};
+
+    static fromSerialized(ownerId, json){
+        let ownerPart = window.System.partsById[ownerId];
+        if(!ownerPart){
+            throw new Error(`Could not find owner part id ${ownerId} on deserialization!`);
+        }
+        let instance = new this(ownerPart);
+        instance.setFromDeserialized(json);
+        ownerPart.addPart(instance);
+        return instance;
+    };
+}
 
 export {
     Window,

--- a/js/objects/parts/WorldStack.js
+++ b/js/objects/parts/WorldStack.js
@@ -88,19 +88,16 @@ class WorldStack extends Part {
     delegateMessage(aMessage){
         return this.sendMessage(aMessage, window.System);
     }
-};
 
-
-/**
- * Constructs the appropriate Part based
- * on the incoming serialization string, which
- * should be JSON valid
- */
-WorldStack.fromSerialization = function(aString){
-    let json = JSON.parse(aString);
-    let newPart = new WorldStack();
-    newPart.setFromDeserialized(json);
-    return newPart;
+    static fromSerialized(ownerId, json){
+        // Unlike the default Part.js implementation,
+        // the WorldStack will not have any ownerId
+        // since it is the root in the hierarchy.
+        // so it ignores the first value passed in
+        let instance = new this();
+        instance.setFromDeserialized(json);
+        return instance;
+    }
 };
 
 export {

--- a/js/objects/tests/preload.js
+++ b/js/objects/tests/preload.js
@@ -34,10 +34,3 @@ global.window.System = System;
 // object -- which here is already defined
 // in jsdom -- it will call those automatically.
 // Calling them twice will produce errors!
-
-/*import { Window } from 'happy-dom';
-const window = new Window();
-const document = window.document;
-global.window = window;
-global.document = document;
-global.HTMLElement = window.HTMLElement;*/

--- a/js/objects/tests/test-serialization-with-preload.js
+++ b/js/objects/tests/test-serialization-with-preload.js
@@ -1,0 +1,75 @@
+/**
+ * Serialization / Deserialization Tests
+ * ---------------------------------------------
+ * Integration tests to ensure that JSON serialization
+ * and saving whole HTML of application work as
+ * expected
+ */
+import chai from 'chai';
+const assert = chai.assert;
+const expect = chai.expect;
+
+function getSerializationString(){
+    System.serialize();
+    let serializationEl = document.getElementById('serialization');
+    return serializationEl.textContent;
+}
+
+describe("Serialization / Deserialization Tests", () => {
+    describe("JSON Serialization Tests", () => {
+        // We will create a new button to
+        // test serialization
+        let foundButton;
+        
+        it("Can match itself on multiple serializations", () => {
+            System.serialize();
+            var serializationEl = document.getElementById('serialization');
+            let first = serializationEl.textContent;
+            System.serialize();
+            var serializationEl = document.getElementById('serialization');
+            let second = serializationEl.textContent;
+            assert.equal(first, second);
+        });
+        it("Deserializing from itself will produce and identical JSON serialization", () => {
+            let first = getSerializationString();
+            // Clear models and views
+            System.partsById = {};
+            document.querySelector('st-world').remove();
+            System.deserialize();
+            let second = getSerializationString();
+            assert.equal(first, second);
+        });
+        it('Adding a button to current card will be serialized', () => {
+            let currentCard = System.getCurrentCardModel();
+            System.newModel('button', currentCard.id, "My New Button");
+            foundButton = currentCard.subparts.find(subpart => {
+                let name = subpart.partProperties.getPropertyNamed(
+                    subpart,
+                    'name'
+                );
+                return name == "My New Button";
+            });
+            assert.exists(foundButton);
+            let serialization = getSerializationString();
+            let json = JSON.parse(serialization);
+            assert.include(Object.keys(json.parts), foundButton.id.toString());
+        });
+        it("Loading from new serialization, we get the correct button", () => {
+            // Clear models and viewa
+            System.partsById = {};
+            document.querySelector('st-world').remove();
+            System.deserialize();
+            assert.exists(System.partsById[foundButton.id]);
+        });
+    });
+
+    describe("HTML saving tests", () => {
+        it("Can match itself on multiple saves", () => {
+            System.serialize();
+            let first = System.getFullHTMLString();
+            System.serialize();
+            let second = System.getFullHTMLString();
+            assert.equal(first, second);
+        });
+    });
+});

--- a/js/objects/utils/idMaker.js
+++ b/js/objects/utils/idMaker.js
@@ -1,4 +1,4 @@
-/**
+i/**
  * ID Maker
  * ------------------------------------
  * I am responsible for creating globally

--- a/js/objects/utils/idMaker.js
+++ b/js/objects/utils/idMaker.js
@@ -1,4 +1,4 @@
-i/**
+/**
  * ID Maker
  * ------------------------------------
  * I am responsible for creating globally

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -64,11 +64,6 @@ class ButtonView extends PartView {
         this['onclick'] = this.onClick;
         this['ondragstart'] = this.onDragstart;
         this['ondragend'] = this.onDragend;
-
-        let buttonName = this.model.partProperties.getPropertyNamed(this, "name");
-        if(buttonName){
-            this.innerText = buttonName;
-        };
     }
 
     afterDisconnected(){
@@ -78,6 +73,13 @@ class ButtonView extends PartView {
         this['onclick'] = null;
         this['ondragstart'] = null;
         this['ondragend'] = null;
+    }
+
+    afterModelSet(){
+        let buttonName = this.model.partProperties.getPropertyNamed(this, "name");
+        if(buttonName){
+            this.innerText = buttonName;
+        };
     }
 
     // We overwrite the PartView.onHaloOpenEditor for the moment

--- a/js/objects/views/WorldView.js
+++ b/js/objects/views/WorldView.js
@@ -39,7 +39,7 @@ class WorldView extends PartView {
         this.onPropChange('currentStack', this.updateCurrentStack);
     }
 
-    afterConnected(){
+    afterModelSet(){
         // If the model specifies a current stack,
         // update it.
         let currStackId = this.model.partProperties.getPropertyNamed(


### PR DESCRIPTION
## What ##
This PR ensures that IDs are preserved and correctly loaded again across the serialization / deserialization lifecycle.
  
## Implementation ##
The previous issue was that some Parts, like the Stack, will create an initial Card as a subpart of themselves when constructed. This was throwing off our `idMaker` module, which for the moment is a dumb incrementer. 
  
The strategy employed here does the following:
1. Ensures that each Part knows how to deserialize itself, via a class method `fromSerialized`. This method should return a Part instance. Note that WorldStack and Window have special behavior for this method. Otherwise all other parts use the Part.js base implementation
2. Resets the `idMaker`'s count to be the maximum ID value once all Parts have been deserialized. This ensures that the "next" created Part by the user will have the correct next ID, and that there are not clashes.
  
Additionally, I have adjusted some methods here and there to make them easier to test.
  
## Tests ##
There is now a [preload test file for serialization/deseralization](https://github.com/UnitedLexCorp/SimpleTalk/blob/eric-serialization-ids/js/objects/tests/test-serialization-with-preload.js). We test both the JSON parts and the saving of the HTML document. They are currently passing fine.