### PR TITLE
Fixing Field Serialization Issue

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -867,7 +867,7 @@ const System = {
         if(world){
             world.remove();
         }
-        return new window.XMLSerializer().serializeToString(clonedDocument);
+        return clonedDocument.documentElement.outerHTML;
     },
 
 

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -132,6 +132,43 @@ class Field extends Part {
         this.setupStyleProperties();
     }
 
+    /**
+     * Serialize this Field's state as JSON.
+     * We override the default Part.js
+     * implementation so that the textContent
+     * property is not saved. This prevents it
+     * from being set (rather than htmlContent)
+     * on deserialization
+     */
+    serialize(){
+        let ownerId = null;
+        if(this._owner){
+            ownerId = this._owner.id;
+        }
+        let result = {
+            type: this.type,
+            id: this.id,
+            properties: {},
+            subparts: this.subparts.map(subpart => {
+                return subpart.id;
+            }),
+            ownerId: ownerId
+        };
+        this.partProperties._properties.forEach(prop => {
+            let name = prop.name;
+            if(name !== 'textContent'){
+                let value = prop.getValue(this);
+                // If this is the events set, transform
+                // it to an Array first (for serialization)
+                if(name == 'events'){
+                    value = Array.from(value);
+                }
+                result.properties[name] = value;
+            }
+        });
+        return result;
+    }
+
     get type(){
         return 'field';
     }


### PR DESCRIPTION
## What
There was an issue when saving a snapshot where XMLSerializer was
escaping HTML characters inside of JSON inside of a script tag.

Instead, we no longer use XMLSerializer and simply get the outerHTML
of the document's documentElement.
  
Additionally, we are no longer serializing the `textContent` property for Fields at all. See the override definition of `serialize()` in the `Field.js` Part class.