### PR TITLE
[BUGFIX] Parts on a Stack can now be moved when halo open

### DIFF
--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -580,6 +580,15 @@ class PartView extends HTMLElement {
             return true;
         }
 
+        let hasLayout = parentModel.partProperties.findPropertyNamed(
+            parentModel,
+            'layout'
+        );
+
+        if(!hasLayout){
+            return true;
+        }
+        
         let parentLayout = parentModel.partProperties.getPropertyNamed(
             parentModel,
             'layout'


### PR DESCRIPTION
-- What
In order to properly manage layouts and ensure that parts inside of an
owner with a list layout cannot me moved (when halo open), we use the
PartView >> #wantsHaloMove getter. This was previously checking for
the value of the owner model's layout property. However, Stacks
don't (for the moment) have layout properties, and thus attempting to
move a Part that was in a Stack triggered a property lookup error.

This has been resolved.