### PR TITLE
Target

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -38,7 +38,7 @@ import ohm from 'ohm-js';
 import interpreterSemantics from '../ohm/interpreter-semantics.js';
 import {ExecutionStack, ActivationContext} from './ExecutionStack.js';
 
-import idMaker from './utils/idMaker.js';
+import idMaker from './utils/id.js';
 
 import handInterface from './utils/handInterface.js';
 

--- a/js/objects/examples/target.html
+++ b/js/objects/examples/target.html
@@ -1,0 +1,1831 @@
+<html xmlns="http://www.w3.org/1999/xhtml"><head>
+    <meta charset="utf-8">
+    <title>System Object Example</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&amp;display=swap" rel="stylesheet"> 
+    <link rel="stylesheet" href="../../../css/core.css">
+    <script src="../../ohm/simpletalk.ohm" type="text/ohm-js"></script>
+    <script src="../build/devSystem.bundle.js"></script>
+<script>(function addTranscript() {
+  function debounce(callback, wait, immediate = false) {
+    let timeout = null;
+
+    return function () {
+      const callNow = immediate && !timeout;
+      const next = () => callback.apply(this, arguments);
+
+      clearTimeout(timeout);
+      timeout = setTimeout(next, wait);
+
+      if (callNow) {
+        next();
+      }
+    };
+  }
+
+  function waitFor(selector, callback, timeout) {
+    const element = document.querySelector(selector);
+    if (element) {
+      callback(element);
+    } else {
+      if (timeout) {
+        return window.setTimeout(() => {
+          return window.requestAnimationFrame(() => {
+            waitFor(selector, callback);
+          });
+        }, timeout);
+      }
+      return window.requestAnimationFrame(() => {
+        waitFor(selector, callback);
+      });
+    }
+  }
+
+  function onVideoChange(cb) {
+    const debouncedCallback = debounce(cb, 200);
+    waitFor(
+      "ytd-player",
+      function handlePlayer(player) {
+        const video = document.querySelector(".html5-main-video");
+        if (!video) {
+          setTimeout(() => handlePlayer(player), 1000);
+          return;
+        }
+        debouncedCallback();
+        const observer = new MutationObserver(debouncedCallback);
+        observer.observe(video, {
+          childList: false,
+          subtree: false,
+          attributes: true,
+        });
+      },
+      100
+    );
+  }
+
+  function renderTranscript() {
+    const player = document.querySelector("ytd-player")?.getPlayer();
+    if (!player) {
+      return;
+    }
+
+    const { isLive, video_id } = player.getVideoData();
+    const options = player.getOptions();
+    const hasCaptions = options.includes("captions");
+
+    if (!hasCaptions || isLive) {
+      document.querySelector("#transcript-info")?.remove();
+      return;
+    }
+
+    document.querySelector("#transcript-info")?.remove();
+
+    const wrapper = document.createElement("div");
+    wrapper.id = `transcript-info`;
+    wrapper.style = `
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin: 0 8px;
+    `.replace("\n", " ");
+
+    const a = document.createElement("a");
+    a.setAttribute("href", `https://video-insights.com/en/video/${video_id}`);
+    a.setAttribute("target", "_blank");
+    a.setAttribute(
+      "style",
+      `
+        color: var(--yt-spec-call-to-action);
+        background-color: transparent;
+        text-transform: uppercase;
+        border: 1px solid var(--yt-spec-call-to-action);
+        padding: var(--yt-button-padding-minus-border);
+        width: var(--yt-paper-button-width, auto);
+        height: var(--yt-paper-button-height, auto);
+        border-radius: inherit;
+        text-align: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        font-size: var(--yt-paper-button-font-size, inherit);
+        transition: var(--shadow-transition_-_transition);
+        margin: var(--yt-button-margin, 0 0.29em);
+        text-transform: uppercase;
+        vertical-align: middle;
+        white-space: nowrap;
+        font-size: var(--ytd-tab-system_-_font-size);
+        font-weight: var(--ytd-tab-system_-_font-weight);
+        letter-spacing: var(--ytd-tab-system_-_letter-spacing);
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        cursor: pointer;
+        -webkit-font-smoothing: var(--paper-font-common-base_-_-webkit-font-smoothing);
+      `.replace(/(\r\n|\n|\r|\s)/gm, "")
+    );
+    a.appendChild(document.createTextNode("Transcript "));
+    wrapper.appendChild(a);
+
+    const root = document.querySelector("ytd-video-owner-renderer");
+    root?.appendChild(wrapper);
+  }
+
+  onVideoChange(renderTranscript);
+})()</script></head>
+
+<body cz-shortcut-listen="true">
+    <style>
+        body {
+            display: block;
+            width: 100vw;
+            height: 100vh;
+            padding: 0;
+            margin: 0;
+        }
+    </style>
+    <div id="template-area">
+    </div>
+
+
+
+<script id="serialization" type="application/json">{
+    "parts": {
+        "1": {
+            "type": "stack",
+            "id": 1,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 1,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {},
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "cantPeek": false,
+                "resizable": false
+            },
+            "subparts": [
+                3,
+                4,
+                23,
+                28,
+                33
+            ],
+            "ownerId": "world"
+        },
+        "3": {
+            "type": "card",
+            "id": 3,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 3,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "click",
+                    "dragenter",
+                    "dragover",
+                    "drop"
+                ],
+                "cssStyle": {
+                    "layout": "strict",
+                    "opacity": 1,
+                    "list-direction": "row",
+                    "list-wrapping": false
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "marked": false,
+                "cantDelete": false,
+                "dontSearch": false,
+                "showPict": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "layout": "strict",
+                "list-direction": "row",
+                "list-wrapping": false,
+                "top-padding": null,
+                "right-padding": null,
+                "bottom-padding": null,
+                "left-padding": null,
+                "list-alignment": null,
+                "list-distribution": null
+            },
+            "subparts": [
+                15,
+                21,
+                22
+            ],
+            "ownerId": 1
+        },
+        "4": {
+            "type": "window",
+            "id": 4,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 4,
+                "name": "Toolbox",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {
+                    "top": "213px",
+                    "left": "2057px",
+                    "display": null,
+                    "opacity": 1,
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "targetId": null,
+                "title": "Toolbox",
+                "isResizable": true,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 213,
+                "left": 2057,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": ""
+            },
+            "subparts": [
+                5
+            ],
+            "ownerId": 1
+        },
+        "5": {
+            "type": "stack",
+            "id": 5,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 5,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {},
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "cantPeek": false,
+                "resizable": false
+            },
+            "subparts": [
+                7
+            ],
+            "ownerId": 4
+        },
+        "7": {
+            "type": "card",
+            "id": 7,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 7,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "click",
+                    "dragenter",
+                    "dragover",
+                    "drop"
+                ],
+                "cssStyle": {
+                    "layout": "list",
+                    "list-direction": "column",
+                    "opacity": 1,
+                    "list-wrapping": false
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "marked": false,
+                "cantDelete": false,
+                "dontSearch": false,
+                "showPict": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "layout": "list",
+                "list-direction": "column",
+                "list-wrapping": false,
+                "top-padding": null,
+                "right-padding": null,
+                "bottom-padding": null,
+                "left-padding": null,
+                "list-alignment": null,
+                "list-distribution": null
+            },
+            "subparts": [
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14
+            ],
+            "ownerId": 5
+        },
+        "8": {
+            "type": "button",
+            "id": 8,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 8,
+                "name": "Add Button to Toolbox",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n    add button to first card of first stack of window \"Toolbox\" of current stack\nend click",
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "opacity": 1,
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": "0",
+                "left": "0",
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 7
+        },
+        "9": {
+            "type": "button",
+            "id": 9,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 9,
+                "name": "Add Button to Card",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n\tadd button to current card\nend click",
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "opacity": 1,
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": "0",
+                "left": "0",
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 7
+        },
+        "10": {
+            "type": "button",
+            "id": 10,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 10,
+                "name": "Add Image to Card",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n    add image to current card\nend click",
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "opacity": 1,
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": "0",
+                "left": "0",
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 7
+        },
+        "11": {
+            "type": "button",
+            "id": 11,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 11,
+                "name": "Add Drawing to Card",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n  add drawing to current card\nend click",
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "opacity": 1,
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": "0",
+                "left": "0",
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 7
+        },
+        "12": {
+            "type": "button",
+            "id": 12,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 12,
+                "name": "Add Field to Card",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n  add field to current card\nend click",
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "opacity": 1,
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": "0",
+                "left": "0",
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 7
+        },
+        "13": {
+            "type": "button",
+            "id": 13,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 13,
+                "name": "Save",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n  saveHTML\nend click",
+                "editorOpen": true,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "opacity": 1,
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": "0",
+                "left": "0",
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 7
+        },
+        "14": {
+            "type": "button",
+            "id": 14,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 14,
+                "name": "Hand Recognition",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n\ttoggleHandDetection\nend click",
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "opacity": 1
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": "0",
+                "left": "0",
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 7
+        },
+        "15": {
+            "type": "button",
+            "id": 15,
+            "properties": {
+                "target": "third button of current card",
+                "contents": null,
+                "enabled": true,
+                "id": 15,
+                "name": "LiteralSpecifier",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n   setTargetTo \"third button of current card\"\n   answer the \"target\"\n   tell target of this button to set \"name\" to \"LiterallySpecified\"\nend click",
+                "editorOpen": true,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "opacity": 1,
+                    "display": null,
+                    "top": "536px",
+                    "left": "1489px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 536,
+                "left": 1489,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 3
+        },
+        "21": {
+            "type": "button",
+            "id": 21,
+            "properties": {
+                "target": "22",
+                "contents": null,
+                "enabled": true,
+                "id": 21,
+                "name": "ObjectSpecifier",
+                "rectangle": "0, 0, 0, 0",
+                "script": "on click\n   setTargetTo third button of current card\n   answer the \"target\"\n   tell target of this button to set \"name\" to \"Object Specified\"\nend click",
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "opacity": 1,
+                    "display": null,
+                    "top": "531px",
+                    "left": "681px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 531,
+                "left": 681,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 3
+        },
+        "22": {
+            "type": "button",
+            "id": 22,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 22,
+                "name": "LiterallySpecified",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "backgroundColor": "rgba(73, 192, 255, 255)",
+                    "opacity": 1,
+                    "display": null,
+                    "top": "385px",
+                    "left": "1081px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "width": "159.8000030517578px",
+                    "height": "86px"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(73, 192, 255, 255)",
+                "transparency": 1,
+                "hide": false,
+                "width": "159.8000030517578px",
+                "height": "86px",
+                "top": 385,
+                "left": 1081,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 3
+        },
+        "23": {
+            "type": "window",
+            "id": 23,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 23,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {
+                    "opacity": 1,
+                    "display": null,
+                    "top": "822px",
+                    "left": "1164px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "targetId": 15,
+                "title": "Script: LiteralSpecifier(button[15])",
+                "isResizable": true,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 822,
+                "left": 1164,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": ""
+            },
+            "subparts": [
+                24
+            ],
+            "ownerId": 1
+        },
+        "24": {
+            "type": "stack",
+            "id": 24,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 24,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {},
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "cantPeek": false,
+                "resizable": false
+            },
+            "subparts": [
+                25
+            ],
+            "ownerId": 23
+        },
+        "25": {
+            "type": "card",
+            "id": 25,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 25,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "click",
+                    "dragenter",
+                    "dragover",
+                    "drop"
+                ],
+                "cssStyle": {
+                    "opacity": 1,
+                    "layout": "list",
+                    "list-direction": "column",
+                    "list-wrapping": false
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "marked": false,
+                "cantDelete": false,
+                "dontSearch": false,
+                "showPict": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "layout": "list",
+                "list-direction": "column",
+                "list-wrapping": false,
+                "top-padding": null,
+                "right-padding": null,
+                "bottom-padding": null,
+                "left-padding": null,
+                "list-alignment": null,
+                "list-distribution": null
+            },
+            "subparts": [
+                26,
+                27
+            ],
+            "ownerId": 24
+        },
+        "26": {
+            "type": "field",
+            "id": 26,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 26,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {
+                    "opacity": 1,
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "horizontal-resizing": "space-fill",
+                    "vertical-resizing": "space-fill",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "mode": "editing",
+                "htmlContent": "<div><div>on click</div><div>   setTargetTo \"third button of current card\"</div><div>   answer the \"target\"</div><div>   tell target of this button to set \"name\" to \"LiterallySpecified\"</div><div>end click</div><br></div>",
+                "autoSelect": false,
+                "autoTab": false,
+                "lockText": false,
+                "showLines": false,
+                "dontWrap": false,
+                "multipleLines": false,
+                "scroll": 0,
+                "sharedText": false,
+                "wideMargins": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 0,
+                "left": 0,
+                "rotate": null,
+                "horizontal-resizing": "space-fill",
+                "vertical-resizing": "space-fill",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 25
+        },
+        "27": {
+            "type": "button",
+            "id": 27,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 27,
+                "name": "Save Script",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "opacity": 1,
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 0,
+                "left": 0,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 25
+        },
+        "28": {
+            "type": "window",
+            "id": 28,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 28,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {
+                    "opacity": 1,
+                    "display": null,
+                    "top": "2481px",
+                    "left": "2089px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "targetId": 21,
+                "title": "Script: ObjectSpecifier(button[21])",
+                "isResizable": true,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 2481,
+                "left": 2089,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": ""
+            },
+            "subparts": [
+                29
+            ],
+            "ownerId": 1
+        },
+        "29": {
+            "type": "stack",
+            "id": 29,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 29,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {},
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "cantPeek": false,
+                "resizable": false
+            },
+            "subparts": [
+                30
+            ],
+            "ownerId": 28
+        },
+        "30": {
+            "type": "card",
+            "id": 30,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 30,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "click",
+                    "dragenter",
+                    "dragover",
+                    "drop"
+                ],
+                "cssStyle": {
+                    "opacity": 1,
+                    "layout": "list",
+                    "list-direction": "column",
+                    "list-wrapping": false
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "marked": false,
+                "cantDelete": false,
+                "dontSearch": false,
+                "showPict": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "layout": "list",
+                "list-direction": "column",
+                "list-wrapping": false,
+                "top-padding": null,
+                "right-padding": null,
+                "bottom-padding": null,
+                "left-padding": null,
+                "list-alignment": null,
+                "list-distribution": null
+            },
+            "subparts": [
+                31,
+                32
+            ],
+            "ownerId": 29
+        },
+        "31": {
+            "type": "field",
+            "id": 31,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 31,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {
+                    "opacity": 1,
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "horizontal-resizing": "space-fill",
+                    "vertical-resizing": "space-fill",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "mode": "editing",
+                "htmlContent": "",
+                "autoSelect": false,
+                "autoTab": false,
+                "lockText": false,
+                "showLines": false,
+                "dontWrap": false,
+                "multipleLines": false,
+                "scroll": 0,
+                "sharedText": false,
+                "wideMargins": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 0,
+                "left": 0,
+                "rotate": null,
+                "horizontal-resizing": "space-fill",
+                "vertical-resizing": "space-fill",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 30
+        },
+        "32": {
+            "type": "button",
+            "id": 32,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 32,
+                "name": "Save Script",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "opacity": 1,
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 0,
+                "left": 0,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 30
+        },
+        "33": {
+            "type": "window",
+            "id": 33,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 33,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {
+                    "opacity": 1,
+                    "display": null,
+                    "top": "820px",
+                    "left": "189px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "targetId": 21,
+                "title": "Script: ObjectSpecifier(button[21])",
+                "isResizable": true,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 820,
+                "left": 189,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": ""
+            },
+            "subparts": [
+                34
+            ],
+            "ownerId": 1
+        },
+        "34": {
+            "type": "stack",
+            "id": 34,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 34,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {},
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "cantPeek": false,
+                "resizable": false
+            },
+            "subparts": [
+                35
+            ],
+            "ownerId": 33
+        },
+        "35": {
+            "type": "card",
+            "id": 35,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 35,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "click",
+                    "dragenter",
+                    "dragover",
+                    "drop"
+                ],
+                "cssStyle": {
+                    "opacity": 1,
+                    "layout": "list",
+                    "list-direction": "column",
+                    "list-wrapping": false
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "marked": false,
+                "cantDelete": false,
+                "dontSearch": false,
+                "showPict": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "layout": "list",
+                "list-direction": "column",
+                "list-wrapping": false,
+                "top-padding": null,
+                "right-padding": null,
+                "bottom-padding": null,
+                "left-padding": null,
+                "list-alignment": null,
+                "list-distribution": null
+            },
+            "subparts": [
+                36,
+                37
+            ],
+            "ownerId": 34
+        },
+        "36": {
+            "type": "field",
+            "id": 36,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 36,
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {
+                    "opacity": 1,
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "horizontal-resizing": "space-fill",
+                    "vertical-resizing": "space-fill",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "mode": "editing",
+                "htmlContent": "<div><div>on click</div><div>   setTargetTo third button of current card</div><div>   answer the \"target\"</div><div>   tell target of this button to set \"name\" to \"Object Specified\"<br></div><div>end click</div><br></div>",
+                "autoSelect": false,
+                "autoTab": false,
+                "lockText": false,
+                "showLines": false,
+                "dontWrap": false,
+                "multipleLines": false,
+                "scroll": 0,
+                "sharedText": false,
+                "wideMargins": false,
+                "background-transparency": 1,
+                "background-color": null,
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 0,
+                "left": 0,
+                "rotate": null,
+                "horizontal-resizing": "space-fill",
+                "vertical-resizing": "space-fill",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 35
+        },
+        "37": {
+            "type": "button",
+            "id": 37,
+            "properties": {
+                "target": null,
+                "contents": null,
+                "enabled": true,
+                "id": 37,
+                "name": "Save Script",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [
+                    "mousedown",
+                    "mouseup",
+                    "mouseenter",
+                    "click",
+                    "dragstart",
+                    "dragend"
+                ],
+                "cssStyle": {
+                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "opacity": 1,
+                    "display": null,
+                    "top": "0px",
+                    "left": "0px",
+                    "horizontal-resizing": "rigid",
+                    "vertical-resizing": "rigid",
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain"
+                },
+                "number": -1,
+                "stepTime": 500,
+                "stepping": false,
+                "selectedText": null,
+                "background-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
+                "hide": false,
+                "width": null,
+                "height": null,
+                "top": 0,
+                "left": 0,
+                "rotate": null,
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "left",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain"
+            },
+            "subparts": [],
+            "ownerId": 35
+        },
+        "world": {
+            "type": "world",
+            "id": "world",
+            "properties": [],
+            "subparts": [
+                1
+            ],
+            "ownerId": null,
+            "loadedStacks": [
+                1
+            ],
+            "currentStack": null
+        }
+    },
+    "currentCardId": 3,
+    "currentStackId": 1
+}</script>
+
+</body></html>

--- a/js/objects/parts/Audio.js
+++ b/js/objects/parts/Audio.js
@@ -24,11 +24,6 @@ class Audio extends Part {
         );
 
         this.partProperties.newBasicProp(
-            "load",
-            null
-        );
-
-        this.partProperties.newBasicProp(
             "stop",
             null
         );
@@ -61,6 +56,7 @@ class Audio extends Part {
 
     play(value){
         this.partProperties.setPropertyNamed(this, "play", value);
+        this.partProperties.setPropertyNamed(this, "stop", false);
     }
 
     stop(){

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -172,6 +172,10 @@ class Part {
         // to ALL Parts in the system.
         let basicProps = [
             new BasicProperty(
+                'target',
+                null,
+            ),
+            new BasicProperty(
                 'contents',
                 null,
             ),

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -4,7 +4,10 @@
  * I represent the prototype object for all
  * SimpleTalk parts.
  */
-import idMaker from '../utils/idMaker.js';
+import {
+    idMaker,
+    isValidId
+} from '../utils/id.js';
 import errorHandler from '../utils/errorHandler.js';
 import {
     PartProperties,
@@ -13,6 +16,7 @@ import {
 } from '../properties/PartProperties.js';
 
 import {ActivationContext} from '../ExecutionStack.js';
+
 
 class Part {
     constructor(anOwnerPart, name, deserializing=false){
@@ -236,15 +240,14 @@ class Part {
             'target',
             function(propOwner, propObject, val){
                 // check to see if the target is a non-ID
-                if(val == null){
-                    propObject._value = null;
-                } else if(val.match(/(?!\d)/g).length > 1){
-                    propObject._value = val;
-                } else {
+                let id = isValidId(val);
+                if(id){
                     // if it is an ID insert "part" since our
                     // grammar doesn't handle ID without system object
                     // prefixes
                     propObject._value = `part id ${val}`;
+                } else {
+                    propObject._value = val;
                 }
             },
             function(propOwner, propObject){

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -66,6 +66,7 @@ class Part {
         this.getOwnerBranch = this.getOwnerBranch.bind(this);
         this.startStepping = this.startStepping.bind(this);
         this.stopStepping = this.stopStepping.bind(this);
+        this.setTargetProp = this.setTargetProp.bind(this);
 
 
         // Finally, we finish initialization
@@ -76,6 +77,7 @@ class Part {
         this.setPrivateCommandHandler("newModel", this.newModelCmdHandler);
         this.setPrivateCommandHandler("openEditor", this.openEditorCmdHandler);
         this.setPrivateCommandHandler("closeEditor", this.closeEditorCmdHandler);
+        this.setPrivateCommandHandler("setTargetTo", this.setTargetProp);
     }
 
     // Convenience getter to get the id
@@ -172,10 +174,6 @@ class Part {
         // to ALL Parts in the system.
         let basicProps = [
             new BasicProperty(
-                'target',
-                null,
-            ),
-            new BasicProperty(
                 'contents',
                 null,
             ),
@@ -234,6 +232,27 @@ class Part {
             [] // No aliases
         );
 
+        this.partProperties.newDynamicProp(
+            'target',
+            function(propOwner, propObject, val){
+                // check to see if the target is a non-ID
+                if(val == null){
+                    propObject._value = null;
+                } else if(val.match(/(?!\d)/g).length > 1){
+                    propObject._value = val;
+                } else {
+                    // if it is an ID insert "part" since our
+                    // grammar doesn't handle ID without system object
+                    // prefixes
+                    propObject._value = `part id ${val}`;
+                }
+            },
+            function(propOwner, propObject){
+                return propObject._value;
+            },
+            false,
+            null,
+        ),
 
         // Stepping related props
 
@@ -485,6 +504,11 @@ class Part {
             commandName: 'deleteModel',
             args: [objectId, modelType]
         });
+    }
+
+    setTargetProp(senders, ...args){
+        let target = args.join(" ");
+        this.partProperties.setPropertyNamed(this, "target", target);
     }
 
     newModelCmdHandler(senders, modelType, ownerId, targetModelType, context, name){

--- a/js/objects/tests/test-audio-with-preload.js
+++ b/js/objects/tests/test-audio-with-preload.js
@@ -55,6 +55,7 @@ describe('Audio Part & View Tests', () => {
             };
             audio.sendMessage(msg, audio.model);
             assert.isTrue(audio.model.partProperties.getPropertyNamed(audio.model, "play"));
+            assert.isFalse(audio.model.partProperties.getPropertyNamed(audio.model, "stop"));
         });
         it('Can tell audio to pause (via message)', () => {
             let audio = document.querySelector('st-card.current-card > st-audio');
@@ -82,7 +83,7 @@ describe('Audio Part & View Tests', () => {
                 args: []
             };
             audio.sendMessage(msg, audio.model);
-            assert.isTrue(audio.model.partProperties.getPropertyNamed(audio.model, "load"));
+            assert.isTrue(audio.model.partProperties.getPropertyNamed(audio.model, "stop"));
             assert.isFalse(audio.model.partProperties.getPropertyNamed(audio.model, "play"));
         });
     });

--- a/js/objects/tests/test-id-utils.js
+++ b/js/objects/tests/test-id-utils.js
@@ -1,0 +1,64 @@
+/**
+ * ID Utility tests  Tests
+ * ---------------------------
+ */
+import chai from 'chai';
+const assert = chai.assert;
+import {
+    idMaker,
+    isValidId
+} from '../utils/id.js';
+
+
+describe('Id Utilities tests', () => {
+    describe('Id Maker tests', () => {
+        before(() => {
+        });
+
+        it('First Id is proper', () => {
+            let newId = idMaker.new();
+            assert.equal(0, newId);
+        });
+        it('Next is proper', () => {
+            let newId = idMaker.new();
+            assert.equal(1, newId);
+        });
+    });
+    describe('Id Checker tests', () => {
+        before(() => {
+        });
+
+        it('Id Maker Checks Out', () => {
+            let newId = idMaker.new();
+            let id = isValidId(newId);
+            assert.equal(2, id);
+        });
+        it('Any natural number is an Id', () => {
+            let id = isValidId(123);
+            assert.equal(123, id);
+        });
+        it('Any string "[natural number]" is an Id', () => {
+            let id = isValidId("123");
+            assert.equal(123, id);
+        });
+        it('Negative integers are not Ids', () => {
+            let id = isValidId(-123);
+            assert.isFalse(id);
+            id = isValidId("-123");
+            assert.isFalse(id);
+        });
+        it('Non integer strings are not Ids', () => {
+            let id = isValidId("123abc");
+            assert.isFalse(id);
+        });
+        it('Null, undefined and empty string are not Ids', () => {
+            let id = isValidId(null);
+            assert.isFalse(id);
+            id = isValidId(undefined);
+            assert.isFalse(id);
+            id = isValidId("");
+            assert.isFalse(id);
+        });
+    });
+
+});

--- a/js/objects/tests/test-object-speficier-with-preload.js
+++ b/js/objects/tests/test-object-speficier-with-preload.js
@@ -465,4 +465,76 @@ describe("ObjectSpecifier Tests", () => {
             });
         });
     });
+    describe("Target specifiers", () => {
+        let semantics;
+        let partContext;
+
+        before(() => {
+            partContext = window.System.getCurrentStackModel();
+            semantics = testLanguageGrammar.createSemantics();
+            semantics.addOperation(
+                'interpret',
+                interpreterSemantics(partContext, window.System)
+            );
+            // we need to add the semantics to the partContext since
+            // we are not actually compiling a script on it
+            // however OHM will throw an grammar(System)-semantics(partContext) mismatch error if we
+            // simply set the above semantics on the partContext
+            partContext._semantics = semantics;
+            window.System.grammar = semantics.getGrammar();
+        });
+
+        it("Can get button 1 of card 2 of current stack from target of button 1 of card 1", () => {
+            // set up the target prop
+            let card1 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[0];
+            let button1Card1 = card1.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            button1Card1.partProperties.setPropertyNamed(
+                button1Card1,
+                'target',
+                'button 1 of card 2 of current stack'
+            );
+            let str = `target of button 1 of card 1 of current stack`;
+            let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+            assert.isTrue(matchObject.succeeded());
+            let secondCard = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[1];
+            let expectedPart = secondCard.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            let expectedValue = expectedPart.id;
+            let result = semantics(matchObject).interpret();
+            assert.equal(expectedValue, result);
+        });
+        it("Can get button 1 of area 1 of card 1 of current stack from target of button 1 of card 1", () => {
+            // set up the target prop
+            let card1 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[0];
+            let button1Card1 = card1.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            button1Card1.partProperties.setPropertyNamed(
+                button1Card1,
+                'target',
+                'button 1 of first area of card 1 of current stack'
+            );
+            let str = `target of button 1 of card 1 of current stack`;
+            let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+            assert.isTrue(matchObject.succeeded());
+            let area = card1.subparts.filter(subpart => {
+                return subpart.type == 'area';
+            })[0];
+            let expectedPart = area.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            let expectedValue = expectedPart.id;
+            let result = semantics(matchObject).interpret();
+            assert.equal(expectedValue, result);
+        });
+    });
 });

--- a/js/objects/tests/test-object-speficier-with-preload.js
+++ b/js/objects/tests/test-object-speficier-with-preload.js
@@ -536,5 +536,86 @@ describe("ObjectSpecifier Tests", () => {
             let result = semantics(matchObject).interpret();
             assert.equal(expectedValue, result);
         });
+        it("Can get target of a target", () => {
+            // set up the target prop
+            let card1 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[0];
+            let button1Card1 = card1.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            button1Card1.partProperties.setPropertyNamed(
+                button1Card1,
+                'target',
+                'button 1 of card 2 of current stack'
+            );
+            let card2 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[1];
+            let button1Card2 = card2.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            button1Card2.partProperties.setPropertyNamed(
+                button1Card2,
+                'target',
+                'button 1 of card 3 of current stack'
+            );
+            let str = `target of target of button 1 of card 1 of current stack`;
+            let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+            assert.isTrue(matchObject.succeeded());
+            // check the object ids
+            let card3 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[2];
+            let button1Card3 = card3.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            let expectedValue = button1Card3.id;
+            let result = semantics(matchObject).interpret();
+            assert.equal(expectedValue, result);
+        });
+        it("Can get target of a target of a target", () => {
+            // set up the target prop
+            let card1 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[0];
+            let button1Card1 = card1.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            button1Card1.partProperties.setPropertyNamed(
+                button1Card1,
+                'target',
+                'button 1 of card 2 of current stack'
+            );
+            let card2 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[1];
+            let button1Card2 = card2.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            button1Card2.partProperties.setPropertyNamed(
+                button1Card2,
+                'target',
+                'button 1 of card 3 of current stack'
+            );
+            let card3 = partContext.subparts.filter(subpart => {
+                return subpart.type == 'card';
+            })[2];
+            let button1Card3 = card3.subparts.filter(subpart => {
+                return subpart.type == 'button';
+            })[0];
+            button1Card3.partProperties.setPropertyNamed(
+                button1Card3,
+                'target',
+                'button 1 of card 1 of current stack' // back to card1 button1
+            );
+            let str = `target of target of target of button 1 of card 1 of current stack`;
+            let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+            assert.isTrue(matchObject.succeeded());
+            // check the object ids
+            let expectedValue = button1Card1.id;
+            let result = semantics(matchObject).interpret();
+            assert.equal(expectedValue, result);
+        });
     });
 });

--- a/js/objects/tests/test-object-speficier-with-preload.js
+++ b/js/objects/tests/test-object-speficier-with-preload.js
@@ -11,6 +11,7 @@ let fields = [];
 let buttons = [];
 let cards = [];
 let currentCardModel = null;
+let area = null;
 
 // Helper function that adds cards, buttons, and
 // fields to the current stack.
@@ -51,6 +52,17 @@ function setupCardsAndParts(){
             currentCard.id,
             `Field ${3}`
         );
+        let areaModel = window.System.newModel(
+            'area',
+            currentCard.id,
+            `Area ${1}`
+        );
+        window.System.newModel(
+            'button',
+            areaModel.id,
+            `Area Button ${1}`
+        );
+
         if(i < 2){
             window.System.newModel(
                 'card',
@@ -324,6 +336,133 @@ describe("ObjectSpecifier Tests", () => {
             let expectedValue = expectedPart.id;
             let result = semantics(matchObject).interpret();
             assert.equal(expectedValue, result);
+        });
+    });
+    describe("Complex Specifiers without terminal", () => {
+        describe("Context is current card", () => {
+            let semantics;
+            let partContext;
+
+            before(() => {
+                partContext = window.System.getCurrentCardModel();
+                semantics = testLanguageGrammar.createSemantics();
+                semantics.addOperation(
+                    'interpret',
+                    interpreterSemantics(partContext, window.System)
+                );
+            });
+
+            it("Can get button 1 of area 1 ", () => {
+                let str = `button 1 of area 1`;
+                let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+                assert.isTrue(matchObject.succeeded());
+                let firstArea = partContext.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                })[0];
+                let expectedPart = firstArea.subparts.filter(subpart => {
+                    return subpart.type == 'button';
+                })[0];
+                let expectedValue = expectedPart.id;
+                let result = semantics(matchObject).interpret();
+                assert.equal(expectedValue, result);
+            });
+            it("Can get button 1 of area 1 of card 1", () => {
+                let str = `button 1 of area 1 of card 1`;
+                let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+                assert.isTrue(matchObject.succeeded());
+                let firstCard = window.System.getCurrentStackModel().subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                })[0];
+                let firstArea = firstCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                })[0];
+                let expectedPart = firstArea.subparts.filter(subpart => {
+                    return subpart.type == 'button';
+                })[0];
+                let expectedValue = expectedPart.id;
+                let result = semantics(matchObject).interpret();
+                assert.equal(expectedValue, result);
+            });
+            it("Can get button 1 of area 1 of card 1 of stack 1", () => {
+                let str = `button 1 of area 1 of card 1 of first stack`;
+                let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+                assert.isTrue(matchObject.succeeded());
+                let firstCard = window.System.getCurrentStackModel().subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                })[0];
+                let firstArea = firstCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                })[0];
+                let expectedPart = firstArea.subparts.filter(subpart => {
+                    return subpart.type == 'button';
+                })[0];
+                let expectedValue = expectedPart.id;
+                let result = semantics(matchObject).interpret();
+                assert.equal(expectedValue, result);
+            });
+        });
+        describe("Context is current area of current card", () => {
+            let semantics;
+            let partContext;
+
+            before(() => {
+                let currentCard = window.System.getCurrentCardModel();
+                partContext = currentCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                })[0];
+
+                semantics = testLanguageGrammar.createSemantics();
+                semantics.addOperation(
+                    'interpret',
+                    interpreterSemantics(partContext, window.System)
+                );
+            });
+
+            it("Can get button 1 of area 1 ", () => {
+                let str = `button 1`;
+                let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+                assert.isTrue(matchObject.succeeded());
+                let expectedPart = partContext.subparts.filter(subpart => {
+                    return subpart.type == 'button';
+                })[0];
+                let expectedValue = expectedPart.id;
+                let result = semantics(matchObject).interpret();
+                assert.equal(expectedValue, result);
+            });
+            it("Can get button 1 of area 1 of card 1", () => {
+                let str = `button 1 of area 1 of card 1`;
+                let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+                assert.isTrue(matchObject.succeeded());
+                let firstCard = window.System.getCurrentStackModel().subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                })[0];
+                let firstArea = firstCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                })[0];
+                let expectedPart = firstArea.subparts.filter(subpart => {
+                    return subpart.type == 'button';
+                })[0];
+                let expectedValue = expectedPart.id;
+                let result = semantics(matchObject).interpret();
+                assert.equal(expectedValue, result);
+            });
+            it("Can get button 1 of area 1 of card 1 of stack 1", () => {
+                let str = `button 1 of area 1 of card 1 of first stack`;
+                let matchObject = testLanguageGrammar.match(str, 'ObjectSpecifier');
+                assert.isTrue(matchObject.succeeded());
+                let firstCard = window.System.getCurrentStackModel().subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                })[0];
+                let firstArea = firstCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                })[0];
+                let expectedPart = firstArea.subparts.filter(subpart => {
+                    return subpart.type == 'button';
+                })[0];
+                let expectedValue = expectedPart.id;
+                let result = semantics(matchObject).interpret();
+                assert.equal(expectedValue, result);
+            });
         });
     });
 });

--- a/js/objects/tests/test-property-value-with-preload.js
+++ b/js/objects/tests/test-property-value-with-preload.js
@@ -117,6 +117,5 @@ describe("PropertyValue Interpreter Tests", () => {
             let result = window.System.executionStack.getGlobal('result');
             assert.equal(result, 'TEST_BUTTON');
         });
-        
     });
 });

--- a/js/objects/utils/id.js
+++ b/js/objects/utils/id.js
@@ -1,3 +1,5 @@
+// ID related utilities
+
 /**
  * ID Maker
  * ------------------------------------
@@ -21,7 +23,30 @@ const idMaker = {
     }
 };
 
+/* ID checker
+ * --------------------------------------
+ * I am responsible for checking whether an id is
+ * is valid and returning it if so
+ */
+const isValidId = function(id) {
+    if(id === null || id === undefined || id === ""){
+        return false;
+    }
+    if(Number.isInteger(id) && id >= 0){
+        return id;
+    }
+    id = id.toString();
+    // check to see if the id has any non [0-9]
+    // characters
+    if(id.match(/(?!\d)/g).length > 1){
+        return false;
+
+    }
+    return id;
+};
+
 export {
     idMaker,
+    isValidId,
     idMaker as default
 };

--- a/js/objects/views/AudioView.js
+++ b/js/objects/views/AudioView.js
@@ -44,12 +44,6 @@ class AudioView extends PartView {
                 this.pause();
             }
         });
-        this.onPropChange("load", (value) => {
-            if(value === true){
-                // audio.load() reloads to the beginning
-                this._shadowRoot.querySelector("audio").load();
-            }
-        });
         this.onPropChange("stop", (value) => {
             if(value === true){
                 this._shadowRoot.querySelector("audio").currentTime = 0;

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -616,10 +616,20 @@ const createInterpreterSemantics = (partContext, systemContext) => {
         /** Object Specifiers **/
 
 
+        /**
+         * The partByTarget Partial Specifier
+         * refers to partials that specify a part
+         * specified in the "target" PartProperty
+         * of the context part. The value of the
+         * target property is any valid ObjectSpecifier
+         * string.
+         */
         PartialSpecifier_partByTarget(targetLiteral){
             return (context) => {
                 let targetPropValue = context.partProperties.getPropertyNamed(context, "target");
                 // use the partContext since the context object might not have any semantics set on it
+                // For example, a context object/part which does not have a script which has been
+                // compiled will not have had context._semantics set.
                 let semantics = partContext._semantics;
                 let matchObject = systemContext.grammar.match(targetPropValue, 'ObjectSpecifier');
                 let targetId = semantics(matchObject).interpret();

--- a/js/ohm/interpreter-semantics.js
+++ b/js/ohm/interpreter-semantics.js
@@ -615,6 +615,18 @@ const createInterpreterSemantics = (partContext, systemContext) => {
 
         /** Object Specifiers **/
 
+
+        PartialSpecifier_partByTarget(targetLiteral){
+            return (context) => {
+                let targetPropValue = context.partProperties.getPropertyNamed(context, "target");
+                // use the partContext since the context object might not have any semantics set on it
+                let semantics = partContext._semantics;
+                let matchObject = systemContext.grammar.match(targetPropValue, 'ObjectSpecifier');
+                let targetId = semantics(matchObject).interpret();
+                return systemContext.partsById[targetId];
+            };
+        },
+
         /**
          * The partByIndex Partial Specifier
          * refers to partials that specify a part

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -188,7 +188,8 @@
         // like when `card "some card name"` which will assume the current
         // stack as its target
         PartialSpecifier
-                = (systemObject | "part") stringLiteral --partByName
+                = "target" --partByTarget
+                | (systemObject | "part") stringLiteral --partByName
                 | (systemObject | "part") integerLiteral --partByIndex
                 | numericalKeyword (systemObject | "part") --partByNumericalIndex
         

--- a/js/ohm/simpletalk.ohm
+++ b/js/ohm/simpletalk.ohm
@@ -69,6 +69,7 @@
                | PropertyValue
                | anyLiteral
                | variableName
+               | ObjectSpecifier
 
         // For now, expressions are just the
         // value of a given factor.

--- a/js/ohm/tests/test-object-specifier-grammar.js
+++ b/js/ohm/tests/test-object-specifier-grammar.js
@@ -119,6 +119,25 @@ describe("Partial Specifier Tests", () => {
             });
         });
     });
+    describe("Part by target tests", () => {
+        it("'target is a PartialSpecifier", () => {
+            let str = "target";
+            semanticMatchTest(str, 'PartialSpecifier_partByTarget');
+        });
+    });
+});
+
+describe("Queried Specifier Tests", () => {
+    describe("Target tests", () => {
+        it("Can parse 'target of'", () => {
+            let str = "target of";
+            semanticMatchTest(str, 'QueriedSpecifier_prefixed');
+        });
+        it("Can parse 'target of target of'", () => {
+            let str = "target of target of";
+            semanticMatchTest(str, 'QueriedSpecifier_nested');
+        });
+    });
 });
 
 describe("Compound Specifier Tests (non-terminal)", () => {
@@ -142,6 +161,13 @@ describe("Compound Specifier Tests (non-terminal)", () => {
         it("compoundSpecifierWithTerminal", () => {
             let str = `button "myButton" of card 5 of current stack`;
             semanticMatchTest(str, 'ObjectSpecifier_compoundQueryWithTerminal');
+        });
+        it("Compound with 'target of this' system object", () => {
+            let str = "target of target of";
+            partTypes.forEach(partName => {
+                let str = `target of this ${partName}`;
+                semanticMatchTest(str, 'ObjectSpecifier');
+            });
         });
     });
 });


### PR DESCRIPTION
### Main Points ###

This PR adds a "target" property to the Part class, related grammar and semantic handling as well as some tests. 

The target property can be specified as a string if set directly

```
set "target" to "first button of current card"
```

(as before). Or if using the private `setTargetTo` Part command you can also use an ObjectSpecifier. For example,
 
```
setTargetTo "first button of current card"
setTargetTo first button of current card
```
Will effectively reference the same object, the difference being that the grammar-semantics will render the latter `first button of current card` ObjectSpecifier into a partID. 

For this reason "target" is a DynamicProperty which if given a raw ID will convert it to `part id [ID]` in the setter. This ensures that the target value is always a valid ObjectSpecifier. 

Note, that in order for a command to take an ObjectSpecifier argument I have [added it](https://github.com/UnitedLexCorp/SimpleTalk/compare/daniel-target?expand=1#diff-f189d2a29e6e2a0f4a8cd3a2f8c72779e92347a335215074c196e9bec06c5a80R72) to expressions. In general I think this is good and we want to allow handler to take  object as their arguments. 

For example
```
on changeBgColor objSpec
   set "background-color" to "blue" objSpec
end changheColor
```

The reason that `setTargetTo` is a private Part command/handler as opposed to a grammar defined command is because I think that given the choice to make the grammar smaller or the private/public handler count smaller best is to choose the former. The more we can do with said grammar the more powerful it is and adding things to it when absolutely necessary seems like the best way to go. As opposed to commands, private or public, which we can assume will change more. 

One thing that will not work here, and you can see in the example below 

```
set "target" to "button 'Target' of current card"
```
Since we only have single quote literals in the grammar at the moment and this would require a mix of quote-types. I didn't do anything about this at the moment since it's a design decision for the language which I think require more thought. 

here is an example you can run:

![image](https://user-images.githubusercontent.com/1154326/111867975-b4a8b180-8977-11eb-8335-98da23074410.png)


(which I will upload to slack with the PR) 



