### PR TITLE
Copy and Paste (STClipboard v1)

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -39,6 +39,7 @@ import interpreterSemantics from '../ohm/interpreter-semantics.js';
 import {ExecutionStack, ActivationContext} from './ExecutionStack.js';
 
 import idMaker from './utils/id.js';
+import STClipboard from './utils/clipboard.js';
 
 import handInterface from './utils/handInterface.js';
 
@@ -88,6 +89,9 @@ const System = {
         } else {
             this.loadFromEmpty();
         }
+
+        // Attach a new clipboard instance
+        this.clipboard = new STClipboard(this);
 
         // By this point we should have a WorldView with
         // a model attached.

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -515,7 +515,7 @@ class Part {
 
     pasteCmdHandler(){
         if(!window.System.clipboard.isEmpty){
-            let item = window.System.clipbord.contents[0];
+            let item = window.System.clipboard.contents[0];
             if(item.type == 'simpletalk/json' && this.acceptsSubpart(item.partType)){
                 window.System.clipboard.pasteContentsInto(this);
             }

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -65,6 +65,8 @@ class Part {
         this.deleteModelCmdHandler = this.deleteModelCmdHandler.bind(this);
         this.openEditorCmdHandler = this.openEditorCmdHandler.bind(this);
         this.closeEditorCmdHandler = this.closeEditorCmdHandler.bind(this);
+        this.copyCmdHandler = this.copyCmdHandler.bind(this);
+        this.pasteCmdHandler = this.pasteCmdHandler.bind(this);
         this.isSubpartOfCurrentCard = this.isSubpartOfCurrentCard.bind(this);
         this.isSubpartOfCurrentStack = this.isSubpartOfCurrentStack.bind(this);
         this.getOwnerBranch = this.getOwnerBranch.bind(this);
@@ -82,6 +84,8 @@ class Part {
         this.setPrivateCommandHandler("openEditor", this.openEditorCmdHandler);
         this.setPrivateCommandHandler("closeEditor", this.closeEditorCmdHandler);
         this.setPrivateCommandHandler("setTargetTo", this.setTargetProp);
+        this.setPrivateCommandHandler("copy", this.copyCmdHandler);
+        this.setPrivateCommandHandler("paste", this.pasteCmdHandler);
     }
 
     // Convenience getter to get the id
@@ -503,6 +507,19 @@ class Part {
     setTargetProp(senders, ...args){
         let target = args.join(" ");
         this.partProperties.setPropertyNamed(this, "target", target);
+    }
+
+    copyCmdHandler(){
+        window.System.clipboard.copyPart(this);
+    }
+
+    pasteCmdHandler(){
+        if(!window.System.clipboard.isEmpty){
+            let item = window.System.clipbord.contents[0];
+            if(item.type == 'simpletalk/json' && this.acceptsSubpart(item.partType)){
+                window.System.clipboard.pasteContentsInto(this);
+            }
+        }
     }
 
     /** Property Subscribers

--- a/js/objects/tests/test-clipboard-with-preload.js
+++ b/js/objects/tests/test-clipboard-with-preload.js
@@ -1,0 +1,184 @@
+/**
+ * STClipboard Related Tests
+ */
+import chai from 'chai';
+const assert = chai.assert;
+const expect = chai.expect;
+
+const expectedMimeType = "simpletalk/json";
+
+describe("Basic Copy and Paste Tests", () => {
+    let currentCard;
+    let currentStack;
+    let initialButton;
+    let initialArea;
+    describe("Model setup", () => {
+        it("Can add a button and area to the initial card", () => {
+            currentCard = window.System.getCurrentCardModel();
+            assert.exists(currentCard);
+            initialButton = window.System.newModel('button', currentCard.id, "Initial Button");
+            assert.exists(initialButton);
+            initialArea = window.System.newModel('area', currentCard.id, "Initial Area");
+            assert.exists(initialArea);
+        });
+        it("The System clipboard is empty", () => {
+            assert.isEmpty(window.System.clipboard.contents);
+        });
+        describe("Copying the initial button", () => {
+            it("Places an item into the clipboard contents", () => {
+                window.System.clipboard.copyPart(initialButton);
+                assert.equal(window.System.clipboard.contents.length, 1);
+            });
+            it("Clipboard contents item has correct mimeType", () => {
+                let item = window.System.clipboard.contents[0];
+                assert.equal(item.type, expectedMimeType);
+            });
+            it("The encoded data, when deserialized, has the same type as the copied element", () => {
+                let deserializedItem = JSON.parse(window.System.clipboard.contents[0].data);
+                assert.equal(deserializedItem.type, "button");
+            });
+        });
+        describe("Pasting the initial button into the area", () => {
+            it("Can paste the clipboard contents (button) into the area on the card without error", () => {
+                let pasteAction = function(){
+                    window.System.clipboard.pasteContentsInto(initialArea);
+                };
+                expect(pasteAction).to.not.throw();
+            });
+            it("The Area now has one subpart that is a button", () => {
+                assert.equal(initialArea.subparts.length, 1);
+                assert.equal(initialArea.subparts[0].type, "button");
+            });
+            it("The button in the area does *not* have the same id as the initial button", () => {
+                let areaButton = initialArea.subparts.find(subpart =>  { return subpart.type == "button";});
+                assert.notEqual(areaButton.id, initialButton.id);
+            });
+        });
+        describe("Can copy the Area", () => {
+            it("Places an item in to the clipboard contents", () => {
+                window.System.clipboard.copyPart(initialArea);
+                assert.equal(window.System.clipboard.contents.length, 1);
+            });
+            it("Clipboard contents item has correct mimeType", () => {
+                let item = window.System.clipboard.contents[0];
+                assert.equal(item.type, expectedMimeType);
+            });
+            it("The encoded data, when deserialized, has the same type as the copied element", () => {
+                let deserializedItem = JSON.parse(window.System.clipboard.contents[0].data);
+                assert.equal(deserializedItem.type, "area");
+            });
+            it("Can create and navigate to a new card", () => {
+                currentStack = window.System.getCurrentStackModel();
+                window.System.newModel('card', currentStack.id, "Second Card");
+                window.System.goToNextCard();
+                currentCard = window.System.getCurrentCardModel();
+                let secondStackCard = currentStack.subparts.filter(subpart => {
+                    return subpart.type == "card";
+                })[1];
+                assert.equal(
+                    currentCard.id,
+                    secondStackCard.id
+                );
+            });
+        });
+        describe("Can paste the area (into new card)", () => {
+            it("The current card has no area subparts", () => {
+                let areas = currentCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                });
+                assert.equal(areas.length, 0);
+            });
+            it("Can paste the clipboard contents (area) into a new card without error", () => {
+                let pasteAction = function(){
+                    window.System.clipboard.pasteContentsInto(currentCard);
+                };
+                expect(pasteAction).to.not.throw();
+            });
+            it("The card now has one area subpart", () => {
+                let areas = currentCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                });
+                assert.equal(areas.length, 1);
+            });
+            it("The pasted area does *not* have the same id as the initial area", () => {
+                let pastedArea = currentCard.subparts.find(subpart => { return subpart.type == 'area';});
+                assert.notEqual(pastedArea.id, initialArea.id);
+            });
+            it("The pasted area has the name name as the initial area", () => {
+                let pastedArea = currentCard.subparts.find(subpart => { return subpart.type == 'area';});
+                let pastedName = pastedArea.partProperties.getPropertyNamed(
+                    pastedArea,
+                    'name'
+                );
+                let originalName = initialArea.partProperties.getPropertyNamed(
+                    initialArea,
+                    'name'
+                );
+                assert.equal(pastedName, originalName);
+            });
+        });
+        describe("Can copy the current card", () => {
+            it("Places an item into the clipboard contents", () => {
+                window.System.clipboard.copyPart(currentCard);
+                assert.equal(window.System.clipboard.contents.length, 1);
+            });
+            it("Clipboard contents item has correct mimeType", () => {
+                let item = window.System.clipboard.contents[0];
+                assert.equal(item.type, expectedMimeType);
+            });
+            it("The encoded data, when deserialized, has the same type as the copied element", () => {
+                let deserializedItem = JSON.parse(window.System.clipboard.contents[0].data);
+                assert.equal(deserializedItem.type, "card");
+            });
+        });
+        describe("Can paste the current card into the current stack", () => {
+            it("The current stack only has 2 cards to start", () => {
+                let cards = currentStack.subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                });
+                assert.equal(cards.length, 2);
+            });
+            it("Can paste the clipboard contents (card) into the stack without error", () => {
+                let pasteAction = function(){
+                    window.System.clipboard.pasteContentsInto(currentStack);
+                };
+                expect(pasteAction).to.not.throw();
+            });
+            it("The current stack now has 3 cards", () => {
+                let cards = currentStack.subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                });
+                assert.equal(cards.length, 3);
+            });
+            it("The pasted card does *not* have the same id as the copied card", () => {
+                let cards = currentStack.subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                });
+                let pastedCard = cards[2];
+                let copiedCard = cards[1];
+                assert.notEqual(pastedCard.id, copiedCard.id);
+            });
+            it("The pasted card has an area", () => {
+                let pastedCard = currentStack.subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                })[2];
+                let areas = pastedCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                });
+                assert.equal(areas.length, 1);
+            });
+            it("The area in the pasted card has a button", () => {
+                let pastedCard = currentStack.subparts.filter(subpart => {
+                    return subpart.type == 'card';
+                })[2];
+                let area = pastedCard.subparts.filter(subpart => {
+                    return subpart.type == 'area';
+                })[0];
+                let buttons = area.subparts.filter(subpart => {
+                    return subpart.type == 'button';
+                });
+                assert.equal(buttons.length, 1);
+            });
+        });
+    });
+});

--- a/js/objects/tests/test-system-model-add-remove-preload.js
+++ b/js/objects/tests/test-system-model-add-remove-preload.js
@@ -166,40 +166,6 @@ describe('newModel tests', () => {
     });
 });
 
-describe('copyModel tests', () => {
-    it('Can send copyModel message ', () => {
-        let cards = document.querySelectorAll('st-card');
-        assert.isAtLeast(cards.length, 1);
-        let card1 = cards[0];
-
-        let card1Buttons = card1.model.subparts.filter(item => {
-            return item.type === 'button';
-        });
-        assert.isAtLeast(card1Buttons.length, 1);
-
-        let button = card1Buttons[0];
-
-        // add a copy of the card1 button to card2
-        let msg = {
-            type: 'command',
-            commandName: 'copyModel',
-            args: [button.id, card1.model.id]
-        };
-        let sendFunc = function(){
-            currentCard.sendMessage(msg, currentCard);
-        };
-        expect(sendFunc).to.not.throw(Error);
-
-        let card1ButtonsAfter = card1.model.subparts.filter(item => {
-            return item.type === 'button';
-        });
-
-        assert.equal(card1ButtonsAfter.length, card1Buttons.length + 1);
-
-    });
-
-});
-
 describe('deleteModel tests', () => {
     beforeEach(function() {
         let msg = {

--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -52,16 +52,22 @@ class STClipboard {
 
                 // Reset the top and left values so that the
                 // pasted part doesn't run outside of new relative bounds
-                copiedPart.partProperties.setPropertyNamed(
-                    copiedPart,
-                    'top',
-                    10
-                );
-                copiedPart.partProperties.setPropertyNamed(
-                    copiedPart,
-                    'left',
-                    10
-                );
+                let hasTop = copiedPart.partProperties.findPropertyNamed('top');
+                let hasLeft = copiedPart.partProperties.findPropertyNamed('left');
+                if(hasTop){
+                    copiedPart.partProperties.setPropertyNamed(
+                        copiedPart,
+                        'top',
+                        10
+                    );
+                }
+                if(hasLeft){
+                    copiedPart.partProperties.setPropertyNamed(
+                        copiedPart,
+                        'left',
+                        10
+                    );
+                }
 
                 // Open a halo on the resulting part
                 let copiedView = document.querySelector(`[part-id="${deserialization.properties.id}"]`);

--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -50,6 +50,19 @@ class STClipboard {
                 let copiedPart = window.System.partsById[deserialization.properties.id];
                 this._recursivelyRecompile(copiedPart);
 
+                // Reset the top and left values so that the
+                // pasted part doesn't run outside of new relative bounds
+                copiedPart.partProperties.setPropertyNamed(
+                    copiedPart,
+                    'top',
+                    10
+                );
+                copiedPart.partProperties.setPropertyNamed(
+                    copiedPart,
+                    'left',
+                    10
+                );
+
                 // Open a halo on the resulting part
                 let copiedView = document.querySelector(`[part-id="${deserialization.properties.id}"]`);
                 copiedView.openHalo();

--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -1,0 +1,125 @@
+/**
+ * Utilities for Clipboard Functionality
+ * ------------------------------------------
+ * For the moment we use a very primitive stand-in
+ * since the Clipboard API is not standardized across
+ * browser implementations.
+ **/
+import idMaker from './idMaker.js';
+class STClipboard {
+    constructor(aSystem){
+        this.system = aSystem;
+        this.contents = [];
+
+        // Bound methods
+        this.copyPart = this.copyPart.bind(this);
+        this.pasteContentsInto = this.pasteContentsInto.bind(this);
+        this._deserializedPastedPart = this._deserializePastedPart.bind(this);
+        this._recursivelyUpdateIds = this._recursivelyUpdateIds.bind(this);
+        this._recursivelySerialize = this._recursivelySerialize.bind(this);
+        this._recursivelyRecompile = this._recursivelyRecompile.bind(this);
+    }
+
+    copyPart(aPart){
+        let rootSerialization = aPart.serialize();
+        this._recursivelySerialize(aPart, rootSerialization);
+        let item = new STClipboardItem(
+            'simpletalk/json',
+            JSON.stringify(rootSerialization)
+        );
+        this.contents = [item];
+    }
+
+    pasteContentsInto(aTargetPart){
+        // For now, we only allow single entries
+        // into this mock clipboard.
+        if(this.contents.length){
+            let content = this.contents[0].data;
+            let deserialization = JSON.parse(content);
+            if(aTargetPart.acceptsSubpart(deserialization.type)){
+                this._recursivelyUpdateIds(deserialization, null);
+                this._deserializePastedPart(deserialization, aTargetPart);
+            } else {
+                console.warn(`${aTargetPart.type}[${aTargetPart.id}] does not accept subparts of type ${deserialization.type}`);
+            }
+        }
+    }
+
+    _deserializePastedPart(deserialization, anOwnerPart){
+        let partClass = this.system.availableParts[deserialization.type];
+        if(!partClass){
+            throw new Error(`Cannot deserialize Part of type ${aPartJSON.type}!`);
+        }
+        let partCopy = partClass.fromSerialized(anOwnerPart.id, deserialization);
+        this.system.partsById[partCopy.id] = partCopy;
+
+        // Add the system as a prop subscriber
+        partCopy.addPropertySubscriber(this.system);
+
+        // Tell the system to build a view for the part
+        this.system.newView(partCopy.type, partCopy.id);
+
+        // Recursively do the same for any subparts
+        deserialization.subparts.forEach(subpartSerialization => {
+            this._deserializePastedPart(
+                subpartSerialization,
+                partCopy
+            );
+        });
+    }
+
+    _recursivelyRecompile(aPart){
+        // Recursively recompile all scripts
+        // (if present) on the given part and all
+        // descendant subparts
+        let scriptText = aPart.partProperties.getPropertyNamed(
+            aPart,
+            'script'
+        );
+        if(scriptText){
+            aPart.partProperties.setPropertyNamed(
+                aPart,
+                'script',
+                scriptText
+            );
+        }
+        aPart.subparts.forEach(subpart => {
+            this._recursivelyRecompile(subpart);
+        });
+    }
+
+    _recursivelySerialize(aPart, serialization){
+        serialization.subparts = [];
+        aPart.subparts.forEach(subpart => {
+            let subSerial = subpart.serialize();
+            serialization.subparts.push(subSerial);
+            this._recursivelySerialize(subpart, subSerial);
+        });
+    }
+
+    _recursivelyUpdateIds(aDeserialization, parentDeserialization){
+        aDeserialization.id = idMaker.new();
+        if(parentDeserialization){
+            aDeserialization.ownerId = parentDeserialization.id;
+        }
+        aDeserialization.subparts.forEach(subpart => {
+            this._recursivelyUpdateIds(subpart, aDeserialization);
+        });
+    }
+}
+
+class STClipboardItem {
+    constructor(mimeType, data){
+        if(mimeType){
+            this.type = mimeType;
+        }
+        if(data){
+            this.data = data;
+        }
+    }
+};
+
+export {
+    STClipboard,
+    STClipboard as default
+};

--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -5,7 +5,7 @@
  * since the Clipboard API is not standardized across
  * browser implementations.
  **/
-import idMaker from './idMaker.js';
+import idMaker from './id.js';
 class STClipboard {
     constructor(aSystem){
         this.system = aSystem;
@@ -125,7 +125,7 @@ class STClipboard {
     }
 
     get isEmpty(){
-        return this.contents.length > 0;
+        return this.contents.length <= 0;
     }
 }
 

--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -25,7 +25,8 @@ class STClipboard {
         this._recursivelySerialize(aPart, rootSerialization);
         let item = new STClipboardItem(
             'simpletalk/json',
-            JSON.stringify(rootSerialization)
+            JSON.stringify(rootSerialization),
+            aPart.type
         );
         this.contents = [item];
     }
@@ -122,16 +123,34 @@ class STClipboard {
             this._recursivelyUpdateIds(subpart, aDeserialization);
         });
     }
+
+    get isEmpty(){
+        return this.contents.length > 0;
+    }
 }
 
 class STClipboardItem {
-    constructor(mimeType, data){
+    constructor(mimeType, data, partType){
         if(mimeType){
             this.type = mimeType;
+        }
+        if(partType){
+            this._partType = partType;
         }
         if(data){
             this.data = data;
         }
+    }
+
+    get partType(){
+        if(this.type == 'simpletalk/json'){
+            return this._partType;
+        }
+        return null;
+    }
+
+    set partType(val){
+        this._partType = val;
     }
 };
 

--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -37,8 +37,22 @@ class STClipboard {
             let content = this.contents[0].data;
             let deserialization = JSON.parse(content);
             if(aTargetPart.acceptsSubpart(deserialization.type)){
+                // Update all IDs so that they are new
                 this._recursivelyUpdateIds(deserialization, null);
+
+                // Recursively create new instances of the part and any
+                // descendant subparts, down the chain
                 this._deserializePastedPart(deserialization, aTargetPart);
+
+                // Recompile the Part's script (if present)
+                // and do the same for all descendant copies
+                let copiedPart = window.System.partsById[deserialization.properties.id];
+                this._recursivelyRecompile(copiedPart);
+
+                // Open a halo on the resulting part
+                let copiedView = document.querySelector(`[part-id="${deserialization.properties.id}"]`);
+                copiedView.openHalo();
+                
             } else {
                 console.warn(`${aTargetPart.type}[${aTargetPart.id}] does not accept subparts of type ${deserialization.type}`);
             }
@@ -98,10 +112,12 @@ class STClipboard {
     }
 
     _recursivelyUpdateIds(aDeserialization, parentDeserialization){
-        aDeserialization.id = idMaker.new();
-        if(parentDeserialization){
-            aDeserialization.ownerId = parentDeserialization.id;
-        }
+        //aDeserialization.id = idMaker.new();
+        // if(parentDeserialization){
+        //     aDeserialization.ownerId = parentDeserialization.id;
+        // }
+        aDeserialization.properties.id = idMaker.new();
+        aDeserialization.id = aDeserialization.properties.id;
         aDeserialization.subparts.forEach(subpart => {
             this._recursivelyUpdateIds(subpart, aDeserialization);
         });

--- a/js/objects/views/ButtonView.js
+++ b/js/objects/views/ButtonView.js
@@ -101,11 +101,7 @@ class ButtonView extends PartView {
             if(event.shiftKey){
                 // prevent triggering the on click message
                 event.preventDefault();
-                if(this.hasOpenHalo){
-                    this.closeHalo();
-                } else {
-                    this.openHalo();
-                }
+                this.onHaloActivationClick(event);
             } else if(!this.hasOpenHalo){
                 // Send the click command message to self
                 this.model.sendMessage({

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -270,7 +270,6 @@ class FieldView extends PartView {
         this.textarea.focus();
         // document.execCommand("defaultParagraphSeparator", false, "br");
         this.setUpToolbar();
-        this.addEventListener('click', this.onClick);
         if(!this.haloModeButton){
             this.initCustomHaloButton();
         }
@@ -279,7 +278,6 @@ class FieldView extends PartView {
     afterDisconnected(){
         this.textarea.removeEventListener('input', this.onInput);
         this.textarea.removeEventListener('keydown', this.onKeydown);
-        this.removeEventListener('click', this.onClick);
     }
 
     afterModelSet(){
@@ -504,16 +502,7 @@ class FieldView extends PartView {
             // if the shift key is pressed we toggle the halo
             if(event.shiftKey){
                 event.preventDefault();
-                event.stopPropagation();
-                if(this.hasOpenHalo){
-                    this.closeHalo();
-                    // toolbar.style.top = `${toolbar.clientHeight + 5}px`;
-                    // toolbar.style.visibility = "hidden";
-                } else {
-                    this.openHalo();
-                    // toolbar.style.top = `-${toolbar.clientHeight + 5}px`;
-                    // toolbar.style.visibility = "unset";
-                }
+                this.onHaloActivationClick(event);
             } else if(event.altKey){
                 let text = document.getSelection().toString();
                 if(text && !this.contextMenuOpen){

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -33,6 +33,23 @@ const growIcon = `
 </svg>
 `;
 
+const copyIcon = `
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-copy" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <rect x="8" y="8" width="12" height="12" rx="2"></rect>
+   <path d="M16 8v-2a2 2 0 0 0 -2 -2h-8a2 2 0 0 0 -2 2v8a2 2 0 0 0 2 2h2"></path>
+</svg>
+`;
+
+const pasteIcon = `
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-clipboard-check" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <path d="M9 5h-2a2 2 0 0 0 -2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-12a2 2 0 0 0 -2 -2h-2"></path>
+   <rect x="9" y="3" width="6" height="4" rx="2"></rect>
+   <path d="M9 14l2 2l4 -4"></path>
+</svg>
+`;
+
 const templateString = `
 <style>
  :host {
@@ -137,6 +154,12 @@ const templateString = `
 </div>
 
 <div id="halo-left-column" class="halo-column">
+    <div id="halo-copy" class="halo-button" title="Copy this Part">
+        ${copyIcon}
+    </div>
+    <div id="halo-paste" class="halo-button" title="Paste the contents of clipboard into this Part">
+        ${pasteIcon}
+    </div>
     <slot name="left-column"></slot>
 </div>
 
@@ -202,6 +225,15 @@ class Halo extends HTMLElement {
             if(!this.targetElement.wantsHaloScriptEdit){
                 this.editor.style.visibility = 'hidden';
             }
+
+            // Copy button
+            this.copier = this.shadowRoot.getElementById('halo-copy');
+            this.copier.addEventListener('click', this.targetElement.onHaloCopy);
+
+
+            // Paste button
+            this.paster = this.shadowRoot.getElementById('halo-paste');
+            this.paster.addEventListener('click', this.targetElement.onHaloPaste);
         }
     }
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -63,6 +63,8 @@ class PartView extends HTMLElement {
         this.onHaloDelete = this.onHaloDelete.bind(this);
         this.onHaloOpenEditor = this.onHaloOpenEditor.bind(this);
         this.onHaloResize = this.onHaloResize.bind(this);
+        this.onHaloPaste = this.onHaloPaste.bind(this);
+        this.onHaloCopy = this.onHaloCopy.bind(this);
         this.onHaloActivationClick = this.onHaloActivationClick.bind(this);
         this.onAuxClick = this.onAuxClick.bind(this);
         this.onClick = this.onClick.bind(this);
@@ -561,6 +563,15 @@ class PartView extends HTMLElement {
         }
         this.model.partProperties.setPropertyNamed(this.model, "width", newWidth);
         this.model.partProperties.setPropertyNamed(this.model, "height", newHeight);
+    }
+
+    onHaloCopy(){
+        window.System.clipboard.copyPart(this.model);
+    }
+
+    onHaloPaste(){
+        window.System.clipboard.pasteContentsInto(this.model);
+        this.closeHalo();
     }
 
     onAuxClick(event){

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -63,7 +63,9 @@ class PartView extends HTMLElement {
         this.onHaloDelete = this.onHaloDelete.bind(this);
         this.onHaloOpenEditor = this.onHaloOpenEditor.bind(this);
         this.onHaloResize = this.onHaloResize.bind(this);
+        this.onHaloActivationClick = this.onHaloActivationClick.bind(this);
         this.onAuxClick = this.onAuxClick.bind(this);
+        this.onClick = this.onClick.bind(this);
 
         // Bind editor related methods
         this.openEditor = this.openEditor.bind(this);
@@ -85,6 +87,9 @@ class PartView extends HTMLElement {
             // to toggle the halo
             this.addEventListener('auxclick', this.onAuxClick);
 
+            // Register default event handlers manually]
+            this['onclick'] = this.onClick;
+
             // Call the lifecycle method when done
             // with the above
             this.afterConnected();
@@ -93,6 +98,7 @@ class PartView extends HTMLElement {
 
     disconnectedCallback(){
         this.removeEventListener('auxclick', this.onAuxClick);
+        this['onclick'] = null;
         this.afterDisconnected();
     }
 
@@ -560,12 +566,34 @@ class PartView extends HTMLElement {
     onAuxClick(event){
         // Should only open halo when middle
         // mouse button is clicked
-        if(event.button == 1 && this.wantsHalo){
+        if(event.button == 1){
             event.preventDefault();
+            this.onHaloActivationClick(event);
+        }
+    }
+
+    onClick(event){
+        if(event.button == 0 && event.shiftKey){
+            event.preventDefault();
+            this.onHaloActivationClick(event);
+        }
+    }
+
+    onHaloActivationClick(event){
+        if(this.wantsHalo){
             if(this.hasOpenHalo){
                 this.closeHalo();
+                console.log('fart');
             } else {
                 event.stopPropagation();
+                // Find any other open Halos
+                // and automatically close them
+                let exSelector = `.editing:not([part-id="${this.model.id}"])`;
+                Array.from(document.querySelectorAll(exSelector)).forEach(openHaloEl => {
+                    openHaloEl.closeHalo();
+                });
+
+                // Finally, open on this view
                 this.openHalo();
             }
         }

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -583,7 +583,6 @@ class PartView extends HTMLElement {
         if(this.wantsHalo){
             if(this.hasOpenHalo){
                 this.closeHalo();
-                console.log('fart');
             } else {
                 event.stopPropagation();
                 // Find any other open Halos


### PR DESCRIPTION
## What ##
This PR implements a first pass at Part copy and paste functionality. To accomplish this we introduce a new `STClipboard` object on the System that handles most of the complexity. Note that it is completely separate from the OS/Browser based clipboard and copy/paste actions (see below).
  
## Implementation ##
### The `STClipboard` Object ###
`STClipboard` represents a kind of SimpleTalk-only clipboard that can be invoked directly by the System. There are two primary methods intended to be the main API:
* `copyPart(aPartObject)` -- This serializes the passed Part into a special store, along with a custom mimeType of `simpletalk/json'`. Note that these serializations, unlike the saveHTML ones, _not_ flattened.
* `pasteContentsInto(aPartObject)` -- This method will attempt to deserialize an object from the clipboard and, if available and if the target part accepts the type, paste a copy of the part into the target object.
  
### A Note on the browser Clipboard API ###
Ideally, we would make extensive use of the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API), which, with permissions granted, would allow us to intercept the copy and paste actions of the operating system and case based upon the mimeType of true clipboard contents. However, Firefox does not yet support even a functional minimal set of the behavior of this API spec.
  
The objects `STClipboard` and `STClipboardItem` have been designed to be future looking, in that they behave almost like the API will expect down the road. Once that is actually implemented in FF and major browsers, we should be able to make minor changes to have true clipboard functionality without a lot of hassle.
  
### Halo Updates ###
#### Copy and Paste Buttons ####
This PR introduces two new buttons for Halos representing copy and paste-into. For the moment these are the only ways to non-JS/console copy and paste Parts.
  
![Screenshot from 2021-03-23 14-41-44](https://user-images.githubusercontent.com/1640299/112200742-e8890e80-8be5-11eb-881d-3f5b1324a261.png)
  
For the moment the paste-into button is not particularly "smart" -- it will appear on all Parts, regardless of whether or not the STClipboard is empty or, if full, whether or not the target accepts the kind of part that will be pasted. This is something we can deal with using messages and/or events, but we need to make some decisions about how that will work.
  
#### Halo Behavior: Only One & Bug Fixes ####
This PR also fixes an issue where middle click was working for the hierarchical Halo toggling, but shift-click wasn't. Now both should have the same behavior.
  
Additionally, we've made an important change: now only one Halo can be open in the current viewport at a given time. This means that selecting open halo on a part will close all other open halos.
  
## Further Work and Decisions ##
Here are some open questions:
* Do we need to start thinking about contextual menus to make the copy/paste UI a bit cleaner?
* How should we handle the copying/pasting of Cards or whole Stacks (since there is no Halo)?
* We still have a `copyModel` command, but it is kind of dead in the water. We should think about a replacement that makes use of STClipboard to do the heavy lifting. How should these commands be structured?
* Do we want an ST-level message to be sent to all accepting Parts in the current card whenever a new STClipboardItem is added? What should the default behavior be?
  
Also feel free to note any other suggestions you have about what we can do in the future.
  
## Tests ##
There is a [preload test file](https://github.com/UnitedLexCorp/SimpleTalk/blob/eric-copy-paste/js/objects/tests/test-clipboard-with-preload.js) for these changes.
  
## Closes ##
#135 