### PR TITLE
Postmerge Fixes

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -701,33 +701,19 @@ const System = {
 
     // return the model corresponding to the current stack
     getCurrentStackModel: function(){
-        // make sure there is only one current-stack
-        let currentStacks = document.querySelectorAll('st-world > st-stack.current-stack');
-        if(currentStacks.length > 1){
-            throw new Error("Found multiple current stacks in world!");
-        }
-        return currentStacks[0].model;
+        let world = this.getWorldStackModel();
+        return world.currentStack;
     },
 
     // return the model corresponding to the current card
     getCurrentCardModel: function(){
-        // there could be multiple current cards (in windows for example) but only one
-        // current-card child of a current-stack
-        let currentStack = document.querySelector('st-world > st-stack.current-stack');
-        let currentCards = currentStack.querySelectorAll(':scope > st-card.current-card');
-        if(currentCards.length > 1){
-            throw "Found multiple current cards in current stack!";
-        }
-        return currentCards[0].model;
+        let currentStack = this.getCurrentStackModel();
+        return currentStack.currentCard;
     },
 
     // return the model corresponding to the world stack
     getWorldStackModel: function(){
-        let worldStack = document.querySelectorAll('st-world');
-        if(worldStack.length > 1){
-            throw "Found multiple world stack!";
-        }
-        return worldStack[0].model;
+        return this.partsById['world'];
     },
 
     // return the model corresponding script editor st-field

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -26,6 +26,14 @@ class Drawing extends Part {
         addPositioningStyleProps(this);
         this.setupStyleProperties();
 
+        // We are using a distinct show-border
+        // property to deal with being able to see
+        // a drawing that is empty
+        this.partProperties.newBasicProp(
+            'show-border',
+            true
+        );
+
         // When drawing from a script/commands,
         // we will use this as the open canvas
         // whose image bytes will be set to the

--- a/js/objects/parts/Part.js
+++ b/js/objects/parts/Part.js
@@ -147,7 +147,7 @@ class Part {
                     name
                 ]
             });
-        } else {
+        } else if(this.acceptsSubpart(partType)){
             this.sendMessage({
                 type: 'command',
                 commandName: 'newModel',
@@ -157,6 +157,16 @@ class Part {
                     name
                 ]
             }, window.System);
+        } else {
+            this.delegateMessage({
+                type: 'command',
+                commandName: 'newModel',
+                args: [
+                    partType,
+                    ownerId,
+                    name
+                ]
+            });
         }
     }
 


### PR DESCRIPTION
## What ##
This PR represents a few bugfixes for issues we discovered after the most recent merge. They include:
* Changes to how `getCurrentCardModel` etc are implemented and used (this affects some aspects of navigation);
* Ensuring that `add <partName>` without an object specifier can deal with ambiguity appropriately (using message delegation)
* Fixing the issue identified in Issue #159 
  
There are still some stack navigation tests failing for reasons I have not yet been able to determine, but that situation already exists on master.
  
## Closes ##
#159 