### PR TITLE
adding a global Interrupt

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -1450,6 +1450,15 @@ System._commandHandlers['toggleHandDetection'] = () => {
     }
 };
 
+System._commandHandlers['globalInterrupt'] = () => {
+    // cycle through all the parts and set the "stepping" property to false
+    Object.values(System.partsById).forEach((part) => {
+        if(part.isStepping){
+            part.partProperties.setPropertyNamed(part, "stepping", false);
+        }
+    });
+};
+
 /** Register the initial set of parts in the system **/
 System.registerPart('card', Card);
 System.registerPart('stack', Stack);
@@ -1522,6 +1531,18 @@ document.addEventListener('DOMContentLoaded', () => {
     // the system
     System.initialLoad();
 });
+
+// global interrupt
+document.addEventListener('keydown', (event) => {
+    if(event.ctrlKey && event.key == 'c'){
+        System.sendMessage({
+            type: "command",
+            commandName: "globalInterrupt",
+            args: []
+        }, System, System);
+    }
+});
+
 
 export {
     System,


### PR DESCRIPTION
### Main points ###

This PR adds a `globalInterrupt` command handler to the System. At the moment it cycles through all parts and set `stepping` to false in those which are stepping. The handler can be called either via message or by keydown ctrl-c combo. 

Tests were added. 

This PR closes issue #129 