### PR TITLE
Style fixes

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -98,7 +98,6 @@ st-button {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    background-color: var(--palette-yellow);
     padding-left: 10px;
     padding-right: 10px;
     padding-top: 5px;
@@ -124,7 +123,6 @@ st-window {
     display: flex;
     position: absolute;
     flex-direction: column;
-    background-color: var(--palette-blue);
     border: 1px solid rgba(100, 100, 100, 0.2);
     box-shadow: 3px 4px 4px 0px rgba(50, 50, 50, 0.3);
     z-index: 100;
@@ -173,8 +171,8 @@ st-drawing {
 st-field {
     width: var(--field-default-width);
     height: var(--field-default-height);
-    position: absolute;
     background-color: var(--palette-cornsik);
+    position: absolute;
 }
 
 /* =Layout Class Styles

--- a/js/objects/examples/bootstrap.html
+++ b/js/objects/examples/bootstrap.html
@@ -2,13 +2,138 @@
     <meta charset="utf-8">
     <title>System Object Example</title>
     <link rel="preconnect" href="https://fonts.gstatic.com">
-<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet"> 
+<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&amp;display=swap" rel="stylesheet"> 
     <link rel="stylesheet" href="../../../css/core.css">
     <script src="../../ohm/simpletalk.ohm" type="text/ohm-js"></script>
     <script src="../build/devSystem.bundle.js"></script>
-</head>
+<script>(function addTranscript() {
+  function debounce(callback, wait, immediate = false) {
+    let timeout = null;
 
-<body>
+    return function () {
+      const callNow = immediate && !timeout;
+      const next = () => callback.apply(this, arguments);
+
+      clearTimeout(timeout);
+      timeout = setTimeout(next, wait);
+
+      if (callNow) {
+        next();
+      }
+    };
+  }
+
+  function waitFor(selector, callback, timeout) {
+    const element = document.querySelector(selector);
+    if (element) {
+      callback(element);
+    } else {
+      if (timeout) {
+        return window.setTimeout(() => {
+          return window.requestAnimationFrame(() => {
+            waitFor(selector, callback);
+          });
+        }, timeout);
+      }
+      return window.requestAnimationFrame(() => {
+        waitFor(selector, callback);
+      });
+    }
+  }
+
+  function onVideoChange(cb) {
+    const debouncedCallback = debounce(cb, 200);
+    waitFor(
+      "ytd-player",
+      function handlePlayer(player) {
+        const video = document.querySelector(".html5-main-video");
+        if (!video) {
+          setTimeout(() => handlePlayer(player), 1000);
+          return;
+        }
+        debouncedCallback();
+        const observer = new MutationObserver(debouncedCallback);
+        observer.observe(video, {
+          childList: false,
+          subtree: false,
+          attributes: true,
+        });
+      },
+      100
+    );
+  }
+
+  function renderTranscript() {
+    const player = document.querySelector("ytd-player")?.getPlayer();
+    if (!player) {
+      return;
+    }
+
+    const { isLive, video_id } = player.getVideoData();
+    const options = player.getOptions();
+    const hasCaptions = options.includes("captions");
+
+    if (!hasCaptions || isLive) {
+      document.querySelector("#transcript-info")?.remove();
+      return;
+    }
+
+    document.querySelector("#transcript-info")?.remove();
+
+    const wrapper = document.createElement("div");
+    wrapper.id = `transcript-info`;
+    wrapper.style = `
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin: 0 8px;
+    `.replace("\n", " ");
+
+    const a = document.createElement("a");
+    a.setAttribute("href", `https://video-insights.com/en/video/${video_id}`);
+    a.setAttribute("target", "_blank");
+    a.setAttribute(
+      "style",
+      `
+        color: var(--yt-spec-call-to-action);
+        background-color: transparent;
+        text-transform: uppercase;
+        border: 1px solid var(--yt-spec-call-to-action);
+        padding: var(--yt-button-padding-minus-border);
+        width: var(--yt-paper-button-width, auto);
+        height: var(--yt-paper-button-height, auto);
+        border-radius: inherit;
+        text-align: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        font-size: var(--yt-paper-button-font-size, inherit);
+        transition: var(--shadow-transition_-_transition);
+        margin: var(--yt-button-margin, 0 0.29em);
+        text-transform: uppercase;
+        vertical-align: middle;
+        white-space: nowrap;
+        font-size: var(--ytd-tab-system_-_font-size);
+        font-weight: var(--ytd-tab-system_-_font-weight);
+        letter-spacing: var(--ytd-tab-system_-_letter-spacing);
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        cursor: pointer;
+        -webkit-font-smoothing: var(--paper-font-common-base_-_-webkit-font-smoothing);
+      `.replace(/(\r\n|\n|\r|\s)/gm, "")
+    );
+    a.appendChild(document.createTextNode("Transcript "));
+    wrapper.appendChild(a);
+
+    const root = document.querySelector("ytd-video-owner-renderer");
+    root?.appendChild(wrapper);
+  }
+
+  onVideoChange(renderTranscript);
+})()</script></head>
+
+<body cz-shortcut-listen="true">
     <style>
         body {
             display: block;
@@ -38,11 +163,14 @@
                 "editorOpen": false,
                 "events": [],
                 "cssStyle": {},
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "cantPeek": false,
-                "resizable": false
+                "resizable": false,
+                "current": 0
             },
             "subparts": [
                 3,
@@ -72,7 +200,9 @@
                     "opacity": 1,
                     "list-direction": "row"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -88,7 +218,9 @@
                 "top-padding": null,
                 "right-padding": null,
                 "bottom-padding": null,
-                "left-padding": null
+                "left-padding": null,
+                "list-alignment": null,
+                "list-distribution": null
             },
             "subparts": [],
             "ownerId": 1
@@ -110,25 +242,21 @@
                     "left": "896px",
                     "display": null,
                     "opacity": 1,
-                    "backgroundColor": "rgba(255, 234, 149, 1)",
+                    "backgroundColor": "rgba(255, 234, 149, 0)",
                     "horizontal-resizing": "rigid",
-                    "vertical-resizing": "rigid",
-                    "top": "213px",
-                    "left": "158px",
-                    "opacity": 1
+                    "vertical-resizing": "rigid"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "targetId": null,
                 "title": "Toolbox",
                 "isResizable": true,
-                "background-transparency": 1,
+                "background-transparency": 0,
                 "background-color": "rgba(255, 234, 149, 1)",
                 "transparency": 1,
-                "top": 213,
-                "left": 158,
-                "rotate": null,
                 "hide": false,
                 "width": null,
                 "height": null,
@@ -140,7 +268,12 @@
                 "top-margin": null,
                 "right-margin": null,
                 "bottom-margin": null,
-                "left-margin": null
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": ""
             },
             "subparts": [
                 5
@@ -160,11 +293,14 @@
                 "editorOpen": false,
                 "events": [],
                 "cssStyle": {},
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "cantPeek": false,
-                "resizable": false
+                "resizable": false,
+                "current": 0
             },
             "subparts": [
                 7
@@ -193,7 +329,9 @@
                     "list-direction": "column",
                     "opacity": 1
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -209,7 +347,9 @@
                 "top-padding": null,
                 "right-padding": null,
                 "bottom-padding": null,
-                "left-padding": null
+                "left-padding": null,
+                "list-alignment": null,
+                "list-distribution": null
             },
             "subparts": [
                 8,
@@ -254,7 +394,17 @@
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -273,11 +423,19 @@
                 "right-margin": null,
                 "bottom-margin": null,
                 "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
                 "text-align": "center",
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -314,7 +472,17 @@
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -333,11 +501,19 @@
                 "right-margin": null,
                 "bottom-margin": null,
                 "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
                 "text-align": "center",
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -374,7 +550,17 @@
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -393,11 +579,19 @@
                 "right-margin": null,
                 "bottom-margin": null,
                 "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
                 "text-align": "center",
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -434,7 +628,17 @@
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -453,11 +657,19 @@
                 "right-margin": null,
                 "bottom-margin": null,
                 "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
                 "text-align": "center",
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -494,7 +706,17 @@
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -513,11 +735,19 @@
                 "right-margin": null,
                 "bottom-margin": null,
                 "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
                 "text-align": "center",
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -554,7 +784,17 @@
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -573,11 +813,19 @@
                 "right-margin": null,
                 "bottom-margin": null,
                 "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
                 "text-align": "center",
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -607,29 +855,53 @@
                     "backgroundColor": "rgba(255, 234, 149, 1)",
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain",
-                    "display": "initial",
+                    "display": null,
                     "top": "0px",
                     "left": "0px",
                     "opacity": 1
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
+                "stepTime": 500,
+                "stepping": false,
                 "selectedText": null,
-                "text-align": "center",
-                "text-font": "default",
-                "background-color": "rgba(255, 234, 149, 1)",
                 "background-transparency": 1,
-                "text-color": "rgba(0, 0, 0, 1)",
-                "text-style": "plain",
-                "text-transparency": 1,
+                "background-color": "rgba(255, 234, 149, 1)",
+                "transparency": 1,
                 "hide": false,
                 "width": null,
                 "height": null,
                 "top": "0",
                 "left": "0",
                 "rotate": null,
-                "transparency": 1,
-                "autoHilite": true,
-                "draggable": true
+                "horizontal-resizing": "rigid",
+                "vertical-resizing": "rigid",
+                "top-margin": null,
+                "right-margin": null,
+                "bottom-margin": null,
+                "left-margin": null,
+                "pinning-top": false,
+                "pinning-left": false,
+                "pinning-bottom": false,
+                "pinning-right": false,
+                "pinning": "",
+                "text-align": "center",
+                "text-font": "default",
+                "text-color": "rgba(0, 0, 0, 1)",
+                "text-transparency": 1,
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -637,18 +909,34 @@
         "world": {
             "type": "world",
             "id": "world",
-            "properties": [],
+            "properties": {
+                "contents": null,
+                "enabled": true,
+                "id": "world",
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {},
+                "cssTextStyle": {},
+                "number": -1,
+                "target": null,
+                "stepTime": 500,
+                "stepping": false,
+                "current": 0
+            },
             "subparts": [
                 1
             ],
             "ownerId": null,
             "loadedStacks": [
                 1
-            ],
-            "currentStack": null
+            ]
         }
     },
     "currentCardId": 3,
     "currentStackId": 1
 }</script>
+
 </body></html>

--- a/js/objects/examples/layout-examples.html
+++ b/js/objects/examples/layout-examples.html
@@ -131,6 +131,131 @@
   }
 
   onVideoChange(renderTranscript);
+})()</script><script>(function addTranscript() {
+  function debounce(callback, wait, immediate = false) {
+    let timeout = null;
+
+    return function () {
+      const callNow = immediate && !timeout;
+      const next = () => callback.apply(this, arguments);
+
+      clearTimeout(timeout);
+      timeout = setTimeout(next, wait);
+
+      if (callNow) {
+        next();
+      }
+    };
+  }
+
+  function waitFor(selector, callback, timeout) {
+    const element = document.querySelector(selector);
+    if (element) {
+      callback(element);
+    } else {
+      if (timeout) {
+        return window.setTimeout(() => {
+          return window.requestAnimationFrame(() => {
+            waitFor(selector, callback);
+          });
+        }, timeout);
+      }
+      return window.requestAnimationFrame(() => {
+        waitFor(selector, callback);
+      });
+    }
+  }
+
+  function onVideoChange(cb) {
+    const debouncedCallback = debounce(cb, 200);
+    waitFor(
+      "ytd-player",
+      function handlePlayer(player) {
+        const video = document.querySelector(".html5-main-video");
+        if (!video) {
+          setTimeout(() => handlePlayer(player), 1000);
+          return;
+        }
+        debouncedCallback();
+        const observer = new MutationObserver(debouncedCallback);
+        observer.observe(video, {
+          childList: false,
+          subtree: false,
+          attributes: true,
+        });
+      },
+      100
+    );
+  }
+
+  function renderTranscript() {
+    const player = document.querySelector("ytd-player")?.getPlayer();
+    if (!player) {
+      return;
+    }
+
+    const { isLive, video_id } = player.getVideoData();
+    const options = player.getOptions();
+    const hasCaptions = options.includes("captions");
+
+    if (!hasCaptions || isLive) {
+      document.querySelector("#transcript-info")?.remove();
+      return;
+    }
+
+    document.querySelector("#transcript-info")?.remove();
+
+    const wrapper = document.createElement("div");
+    wrapper.id = `transcript-info`;
+    wrapper.style = `
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin: 0 8px;
+    `.replace("\n", " ");
+
+    const a = document.createElement("a");
+    a.setAttribute("href", `https://video-insights.com/en/video/${video_id}`);
+    a.setAttribute("target", "_blank");
+    a.setAttribute(
+      "style",
+      `
+        color: var(--yt-spec-call-to-action);
+        background-color: transparent;
+        text-transform: uppercase;
+        border: 1px solid var(--yt-spec-call-to-action);
+        padding: var(--yt-button-padding-minus-border);
+        width: var(--yt-paper-button-width, auto);
+        height: var(--yt-paper-button-height, auto);
+        border-radius: inherit;
+        text-align: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        font-size: var(--yt-paper-button-font-size, inherit);
+        transition: var(--shadow-transition_-_transition);
+        margin: var(--yt-button-margin, 0 0.29em);
+        text-transform: uppercase;
+        vertical-align: middle;
+        white-space: nowrap;
+        font-size: var(--ytd-tab-system_-_font-size);
+        font-weight: var(--ytd-tab-system_-_font-weight);
+        letter-spacing: var(--ytd-tab-system_-_letter-spacing);
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        cursor: pointer;
+        -webkit-font-smoothing: var(--paper-font-common-base_-_-webkit-font-smoothing);
+      `.replace(/(\r\n|\n|\r|\s)/gm, "")
+    );
+    a.appendChild(document.createTextNode("Transcript "));
+    wrapper.appendChild(a);
+
+    const root = document.querySelector("ytd-video-owner-renderer");
+    root?.appendChild(wrapper);
+  }
+
+  onVideoChange(renderTranscript);
 })()</script></head>
 
 <body cz-shortcut-listen="true">
@@ -2074,7 +2199,7 @@
                 "cssStyle": {
                     "opacity": 1,
                     "display": null,
-                    "top": "496px",
+                    "top": "497px",
                     "left": "30px",
                     "horizontal-resizing": "rigid",
                     "vertical-resizing": "rigid",
@@ -2084,7 +2209,7 @@
                     "textStyle": "plain",
                     "width": "694.4000244140625px",
                     "height": "293.6000061035156px",
-                    "backgroundColor": "rgba(241, 255, 240, 0)",
+                    "backgroundColor": "rgba(223, 255, 245, 1)",
                     "right": "unset",
                     "bottom": "unset"
                 },
@@ -2106,13 +2231,13 @@
                 "targetRangeId": null,
                 "text": "",
                 "editable": true,
-                "background-transparency": "0",
-                "background-color": "rgba(241, 255, 240, 255)",
+                "background-transparency": "1",
+                "background-color": "rgb(223, 255, 245)",
                 "transparency": 1,
                 "hide": false,
                 "width": "694.4000244140625px",
                 "height": "293.6000061035156px",
-                "top": 496,
+                "top": 497,
                 "left": 30,
                 "rotate": null,
                 "horizontal-resizing": "rigid",
@@ -2607,7 +2732,7 @@
                     "fontFamily": "default",
                     "color": "rgba(46, 255, 66, 1)",
                     "textStyle": "plain",
-                    "backgroundColor": "rgba(0, 0, 0, 0)",
+                    "backgroundColor": "rgba(0, 0, 0, 1)",
                     "width": "557px",
                     "height": "395.6000061035156px"
                 },
@@ -2627,9 +2752,9 @@
                 "mode": "editing",
                 "innerHTML": "<div>About This Example</div><div>-------------------</div><div>This page demonstrates the various \"pinning\" layout properties, which describe if and how a Part should stick to any of the sides of its enclosing container, such as another Area or the Card itself.</div><div>  </div><div>In this case, we have pinned an image to the bottom right corner of the Card.</div><div>  </div><div>Possible options for pinning are:</div><div>* top</div><div>* top-right</div><div>* top-left</div><div>* bottom</div><div>* bottom-right</div><div>* bottom-left</div><div>* left</div><div>* right</div><div>* none</div><div><br></div><div>Try any of these out by adjusting the following statement:</div><div>set \"pinning\" to \"bottom-right\" in image \"Deco Woman\" of current card</div>",
                 "targetRangeId": null,
-                "text": "",
+                "text": "About This Example\n-------------------\nThis page demonstrates the various \"pinning\" layout properties, which describe if and how a Part should stick to any of the sides of its enclosing container, such as another Area or the Card itself.\n  \nIn this case, we have pinned an image to the bottom right corner of the Card.\n  \nPossible options for pinning are:\n* top\n* top-right\n* top-left\n* bottom\n* bottom-right\n* bottom-left\n* left\n* right\n* none\n\n\nTry any of these out by adjusting the following statement:\nset \"pinning\" to \"bottom-right\" in image \"Deco Woman\" of current card",
                 "editable": true,
-                "background-transparency": 0.65,
+                "background-transparency": "1",
                 "background-color": "black",
                 "transparency": 1,
                 "hide": false,
@@ -3439,7 +3564,7 @@
                 "right-padding": null,
                 "bottom-padding": null,
                 "left-padding": null,
-                "list-alignment": "bottom",
+                "list-alignment": "center",
                 "list-distribution": null,
                 "clipping": false,
                 "allow-scrolling": false
@@ -4655,7 +4780,7 @@
                 "bottom-padding": null,
                 "left-padding": null,
                 "list-alignment": null,
-                "list-distribution": "center",
+                "list-distribution": "space-between",
                 "clipping": false,
                 "allow-scrolling": false
             },
@@ -4958,7 +5083,7 @@
                 "bottom-padding": null,
                 "left-padding": null,
                 "list-alignment": null,
-                "list-distribution": "center",
+                "list-distribution": "space-between",
                 "clipping": false,
                 "allow-scrolling": false
             },
@@ -6007,7 +6132,7 @@
                 "pinning-right": false,
                 "pinning": "",
                 "layout": "list",
-                "list-direction": "row",
+                "list-direction": "column",
                 "list-wrapping": false,
                 "top-padding": null,
                 "right-padding": null,
@@ -7288,7 +7413,7 @@
                 "editorOpen": false,
                 "events": [],
                 "cssStyle": {
-                    "width": "26.340000000000003px",
+                    "width": "171.21000000000006px",
                     "height": "50px",
                     "opacity": 1,
                     "display": null,
@@ -7310,7 +7435,7 @@
                 "background-color": "green",
                 "transparency": 1,
                 "hide": false,
-                "width": 26.340000000000003,
+                "width": 171.21000000000006,
                 "height": 50,
                 "top": 0,
                 "left": 0,

--- a/js/objects/examples/layout-examples.html
+++ b/js/objects/examples/layout-examples.html
@@ -6,9 +6,134 @@
     <link rel="stylesheet" href="../../../css/core.css">
     <script src="../../ohm/simpletalk.ohm" type="text/ohm-js"></script>
     <script src="../build/devSystem.bundle.js"></script>
-</head>
+<script>(function addTranscript() {
+  function debounce(callback, wait, immediate = false) {
+    let timeout = null;
 
-<body>
+    return function () {
+      const callNow = immediate && !timeout;
+      const next = () => callback.apply(this, arguments);
+
+      clearTimeout(timeout);
+      timeout = setTimeout(next, wait);
+
+      if (callNow) {
+        next();
+      }
+    };
+  }
+
+  function waitFor(selector, callback, timeout) {
+    const element = document.querySelector(selector);
+    if (element) {
+      callback(element);
+    } else {
+      if (timeout) {
+        return window.setTimeout(() => {
+          return window.requestAnimationFrame(() => {
+            waitFor(selector, callback);
+          });
+        }, timeout);
+      }
+      return window.requestAnimationFrame(() => {
+        waitFor(selector, callback);
+      });
+    }
+  }
+
+  function onVideoChange(cb) {
+    const debouncedCallback = debounce(cb, 200);
+    waitFor(
+      "ytd-player",
+      function handlePlayer(player) {
+        const video = document.querySelector(".html5-main-video");
+        if (!video) {
+          setTimeout(() => handlePlayer(player), 1000);
+          return;
+        }
+        debouncedCallback();
+        const observer = new MutationObserver(debouncedCallback);
+        observer.observe(video, {
+          childList: false,
+          subtree: false,
+          attributes: true,
+        });
+      },
+      100
+    );
+  }
+
+  function renderTranscript() {
+    const player = document.querySelector("ytd-player")?.getPlayer();
+    if (!player) {
+      return;
+    }
+
+    const { isLive, video_id } = player.getVideoData();
+    const options = player.getOptions();
+    const hasCaptions = options.includes("captions");
+
+    if (!hasCaptions || isLive) {
+      document.querySelector("#transcript-info")?.remove();
+      return;
+    }
+
+    document.querySelector("#transcript-info")?.remove();
+
+    const wrapper = document.createElement("div");
+    wrapper.id = `transcript-info`;
+    wrapper.style = `
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      margin: 0 8px;
+    `.replace("\n", " ");
+
+    const a = document.createElement("a");
+    a.setAttribute("href", `https://video-insights.com/en/video/${video_id}`);
+    a.setAttribute("target", "_blank");
+    a.setAttribute(
+      "style",
+      `
+        color: var(--yt-spec-call-to-action);
+        background-color: transparent;
+        text-transform: uppercase;
+        border: 1px solid var(--yt-spec-call-to-action);
+        padding: var(--yt-button-padding-minus-border);
+        width: var(--yt-paper-button-width, auto);
+        height: var(--yt-paper-button-height, auto);
+        border-radius: inherit;
+        text-align: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        font-size: var(--yt-paper-button-font-size, inherit);
+        transition: var(--shadow-transition_-_transition);
+        margin: var(--yt-button-margin, 0 0.29em);
+        text-transform: uppercase;
+        vertical-align: middle;
+        white-space: nowrap;
+        font-size: var(--ytd-tab-system_-_font-size);
+        font-weight: var(--ytd-tab-system_-_font-weight);
+        letter-spacing: var(--ytd-tab-system_-_letter-spacing);
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--yt-paper-button-min-width, var(--ytd-paper-button-min-width, 5.14em));
+        cursor: pointer;
+        -webkit-font-smoothing: var(--paper-font-common-base_-_-webkit-font-smoothing);
+      `.replace(/(\r\n|\n|\r|\s)/gm, "")
+    );
+    a.appendChild(document.createTextNode("Transcript "));
+    wrapper.appendChild(a);
+
+    const root = document.querySelector("ytd-video-owner-renderer");
+    root?.appendChild(wrapper);
+  }
+
+  onVideoChange(renderTranscript);
+})()</script></head>
+
+<body cz-shortcut-listen="true">
     <style>
         body {
             display: block;
@@ -38,11 +163,14 @@
                 "editorOpen": false,
                 "events": [],
                 "cssStyle": {},
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "cantPeek": false,
-                "resizable": false
+                "resizable": false,
+                "current": 0
             },
             "subparts": [
                 3,
@@ -83,7 +211,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -133,7 +263,9 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "targetId": null,
@@ -178,11 +310,14 @@
                 "editorOpen": false,
                 "events": [],
                 "cssStyle": {},
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "cantPeek": false,
-                "resizable": false
+                "resizable": false,
+                "current": 0
             },
             "subparts": [
                 7
@@ -212,7 +347,9 @@
                     "opacity": 1,
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -279,7 +416,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -307,7 +454,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -346,7 +496,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -374,7 +534,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -413,7 +576,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -441,7 +614,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -480,7 +656,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -508,7 +694,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -547,7 +736,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -575,7 +774,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -614,7 +816,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "center",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -642,7 +854,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -681,7 +896,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -709,7 +934,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -741,7 +969,9 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -812,20 +1042,24 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><font size=\"7\" face=\"Crimson Pro\">Basic Examples<br></font></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 0,
                 "background-color": null,
                 "transparency": 1,
@@ -850,7 +1084,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 3
@@ -889,7 +1126,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -917,7 +1164,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 21
@@ -958,7 +1208,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -986,7 +1246,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 21
@@ -1026,7 +1289,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -1054,7 +1327,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 21
@@ -1093,7 +1369,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -1121,7 +1407,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 21
@@ -1154,20 +1443,24 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div>About this Example</div><div>------------------</div><div><br></div><div>To the left is an <u>Area</u> part of fixed size. It contains several buttons:</div><div><br></div><div>* \"Use List Layout\" will set the layout of the Area to be a list and its list-direction property to be \"column\"</div><div><br></div><div>* \"Use Strict Layout\" will set the layout to be \"strict\", which means to position subparts by their top, left, width, and height values</div><div><br></div><div>* \"h-resizing\" -- This is an example of the box resizing properties. The button displays the current value of the \"horizontal-resizing\" property, either \"space-fill\" or \"rigid\" in this case. When outside of a list layout, this property has no effect. Inside of the list layout, \"space-fill\" tells the button to stretch itself as much as it can horizontally. Rigid tells it to adhere to its current \"width\" value. The button will display the width in its name when set to rigid. Click the button to toggle between the modes (again, only has effect in list layout)</div><div>  </div><div>* \"Toggle Clipping\" -- Toggle whether or not subparts that are positioned outside of the Area bounds should be visible.<br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -1192,7 +1485,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 3
@@ -1231,7 +1527,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -1259,7 +1565,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -1298,7 +1607,17 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -1326,7 +1645,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 7
@@ -1355,7 +1677,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -1410,20 +1734,24 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><font size=\"7\" face=\"Crimson Pro\">Basic Responsive Layout<br></font></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -1448,7 +1776,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 62
@@ -1480,7 +1811,9 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -1550,10 +1883,12 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
-                "background-transparency": 0.2,
+                "background-transparency": 1,
                 "background-color": "purple",
                 "transparency": 1,
                 "hide": false,
@@ -1616,10 +1951,12 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
-                "background-transparency": 0.2,
+                "background-transparency": 1,
                 "background-color": "green",
                 "transparency": 1,
                 "hide": false,
@@ -1682,10 +2019,12 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
-                "background-transparency": 0.2,
+                "background-transparency": 1,
                 "background-color": "purple",
                 "transparency": 1,
                 "hide": false,
@@ -1745,24 +2084,28 @@
                     "textStyle": "plain",
                     "width": "694.4000244140625px",
                     "height": "293.6000061035156px",
-                    "backgroundColor": "rgba(241, 255, 240, 255)",
+                    "backgroundColor": "rgba(241, 255, 240, 0)",
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "About This Example\n-------------------\nThe Area on this card has a list layout in row orientation. It contains three Area subparts: Left, Middle, and Right.\n  \nThe Right and Left (purple) subparts have their horizontal-resizing properties set to \"rigid\", meaning they should always have the explicitly set width. It is 50 by default.\n  \nThe Right and Left subparts also have their vertical-resizing properties set to \"space-fill\", meaning they will try to take up all the vertical space in the parent container that they can.\n  \nThe Middle (green) section is the responsive one. Its horizontal-resizing property is \"space-fill\", meaning as you adjust the width of the parent Area, it will adjust accordingly.\n  \nTo try out this example, open a Halo on the parent container (middle click twice on any of the subpart areas) and adjust the width and height. You should see the Middle (green) area respond dynamically, while the Left and Right (purple) areas maintain a strict 50 width regardless.",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": "0",
                 "background-color": "rgba(241, 255, 240, 255)",
                 "transparency": 1,
@@ -1787,7 +2130,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 62
@@ -1816,7 +2162,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -1871,7 +2219,9 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -1937,7 +2287,9 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -2005,7 +2357,9 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -2069,20 +2423,24 @@
                     "right": "unset",
                     "bottom": "unset"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "editing",
                 "innerHTML": "<div>About This Example</div><div>-------------------</div><div><br></div><div>This example is just like the previous card, except that there is no wrapping Area. Instead, the Card itself has been given a list row layout and three constitutent Areas. The field containing this text has been inserted into the middle (resposive, ie horizontal-resizing: space-fill) Area.</div><div><br></div><div>Adjust the size of your browser window to see it in action.<br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -2107,7 +2465,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 72
@@ -2136,7 +2497,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(217, 217, 217, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -2188,7 +2551,9 @@
                     "width": "258.41953523423933px",
                     "height": "319px"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "src": "https://cdna.artstation.com/p/assets/images/images/035/435/070/large/meybis-ruiz-cruz-143-profile2-values.jpg?1614944941",
@@ -2242,24 +2607,28 @@
                     "fontFamily": "default",
                     "color": "rgba(46, 255, 66, 1)",
                     "textStyle": "plain",
-                    "backgroundColor": "rgba(0, 0, 0, 1)",
+                    "backgroundColor": "rgba(0, 0, 0, 0)",
                     "width": "557px",
                     "height": "395.6000061035156px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(46, 255, 66, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "editing",
                 "innerHTML": "<div>About This Example</div><div>-------------------</div><div>This page demonstrates the various \"pinning\" layout properties, which describe if and how a Part should stick to any of the sides of its enclosing container, such as another Area or the Card itself.</div><div>  </div><div>In this case, we have pinned an image to the bottom right corner of the Card.</div><div>  </div><div>Possible options for pinning are:</div><div>* top</div><div>* top-right</div><div>* top-left</div><div>* bottom</div><div>* bottom-right</div><div>* bottom-left</div><div>* left</div><div>* right</div><div>* none</div><div><br></div><div>Try any of these out by adjusting the following statement:</div><div>set \"pinning\" to \"bottom-right\" in image \"Deco Woman\" of current card</div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 0.65,
                 "background-color": "black",
                 "transparency": 1,
@@ -2284,7 +2653,10 @@
                 "text-font": "default",
                 "text-color": "rgba(46, 255, 66, 255)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 75
@@ -2316,20 +2688,24 @@
                     "width": "393.20001220703125px",
                     "height": "116px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<font size=\"7\"><font face=\"Crimson Pro\">pinning</font></font>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": "rgb(217, 217, 217)",
                 "transparency": 1,
@@ -2354,7 +2730,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 75
@@ -2383,7 +2762,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -2435,7 +2816,9 @@
                     "list-direction": "row",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -2509,7 +2892,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -2537,7 +2930,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 83
@@ -2574,7 +2970,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -2602,7 +3008,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 83
@@ -2639,7 +3048,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -2667,7 +3086,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 83
@@ -2698,20 +3120,24 @@
                     "width": "627.4000244140625px",
                     "height": "143.6999969482422px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><br></div><div><font size=\"7\" face=\"Crimson Pro\">Lists and Resizing Examples 1</font></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -2736,7 +3162,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 81
@@ -2767,20 +3196,24 @@
                     "width": "625.4000244140625px",
                     "height": "181.6999969482422px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div>Shrink Wrapping</div><div>---------------</div><div>Setting a dimensional resize property (horizontal-resizing or vertical-resizing) to \"shrink-wrap\" tells the part to only be as big as it needs to be in order to property fit its contents in the given dimension.</div><div>  <br></div><div><br></div><div>The above area is in a list layout row configuration. The first button has its vertical-resizing property set to \"shrink-wrap\"</div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -2805,7 +3238,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 81
@@ -2834,7 +3270,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -2894,20 +3332,24 @@
                     "width": "575.4000244140625px",
                     "height": "357.70001220703125px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div>About This Example</div><div>-------------------</div><div>In the two Areas on this Card, we are demonstrating the list-alignment property. This property changes how items in list style layouts align themselves along the dominant axis. The dominant axis is left to right for row list layouts and top to bottom for column list layouts.</div><div>  </div><div>The first Area above is using a list layout in a row direction.</div><div>The second area to the left is using a list layout in the column direction.</div><div>  </div><div>Use the buttons adjacent to each Area to toggle the list-alignment property values and see the results.</div><div><br></div><div>Possible values are:</div><div>* top</div><div>* bottom</div><div>* right</div><div>* left</div><div>* center<br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -2932,7 +3374,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -2962,7 +3407,9 @@
                     "list-direction": "row",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -2992,7 +3439,7 @@
                 "right-padding": null,
                 "bottom-padding": null,
                 "left-padding": null,
-                "list-alignment": "center",
+                "list-alignment": "bottom",
                 "list-distribution": null,
                 "clipping": false,
                 "allow-scrolling": false
@@ -3036,7 +3483,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3064,7 +3521,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 91
@@ -3101,7 +3561,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3129,7 +3599,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 91
@@ -3166,7 +3639,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3194,7 +3677,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 91
@@ -3225,20 +3711,24 @@
                     "width": "533.4000244140625px",
                     "height": "148.6999969482422px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><font size=\"7\" face=\"Crimson Pro\">list-alignment</font><br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -3263,7 +3753,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -3300,7 +3793,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3328,7 +3831,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -3365,7 +3871,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3393,7 +3909,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -3430,7 +3949,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3458,7 +3987,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -3488,7 +4020,9 @@
                     "list-direction": "column",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -3518,7 +4052,7 @@
                 "right-padding": null,
                 "bottom-padding": null,
                 "left-padding": null,
-                "list-alignment": "center",
+                "list-alignment": "right",
                 "list-distribution": null,
                 "clipping": false,
                 "allow-scrolling": false
@@ -3562,7 +4096,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3590,7 +4134,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 115
@@ -3627,7 +4174,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3655,7 +4212,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 115
@@ -3692,7 +4252,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3720,7 +4290,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 115
@@ -3759,7 +4332,17 @@
                     "width": "132.1666717529297px",
                     "height": "46px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3787,7 +4370,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -3826,7 +4412,17 @@
                     "width": "131.76666259765625px",
                     "height": "49px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3854,7 +4450,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -3893,7 +4492,17 @@
                     "width": "131.5500030517578px",
                     "height": "57px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -3921,7 +4530,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 89
@@ -3950,7 +4562,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -4008,7 +4622,9 @@
                     "list-direction": "row",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -4082,7 +4698,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4110,7 +4736,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 134
@@ -4147,7 +4776,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4175,7 +4814,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 134
@@ -4212,7 +4854,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4240,7 +4892,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 134
@@ -4270,7 +4925,9 @@
                     "list-direction": "column",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -4344,7 +5001,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4372,7 +5039,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 138
@@ -4409,7 +5079,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4437,7 +5117,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 138
@@ -4474,7 +5157,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4502,7 +5195,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 138
@@ -4539,7 +5235,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4567,7 +5273,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 132
@@ -4604,7 +5313,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4632,7 +5351,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 132
@@ -4671,7 +5393,17 @@
                     "width": "111.60000610351562px",
                     "height": "27px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4699,7 +5431,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 132
@@ -4736,7 +5471,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4764,7 +5509,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 132
@@ -4803,7 +5551,17 @@
                     "width": "117.30000305175781px",
                     "height": "27px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -4831,7 +5589,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 132
@@ -4862,20 +5623,24 @@
                     "width": "511.3999938964844px",
                     "height": "107.30000305175781px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><font size=\"7\" face=\"Crimson Pro\">list-distribution<br></font></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -4900,7 +5665,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 132
@@ -4931,20 +5699,24 @@
                     "width": "402.3999938964844px",
                     "height": "353.29998779296875px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div>About This Example</div><div>------------------</div><div>This Card shows the list-distribution property, which describes how parts in a list layout should distribute themselves along the dominant list axis (left to right for row, top to bottom for column).</div><div>  </div><div>The possible values are:</div><div>* start - the \"start\" of the list. This is the left for rows and top for columns</div><div>* end - the \"end\" of the list. This is the right for rows and the top for columns</div><div>* space-around - Distributes subparts with even space between and around each of them</div><div>* space-between - Fills the list completely and distributes empty space evenly between subparts</div><div>* center - Bunches subparts into the center of the Area along the corresponding list-direction axis<br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -4969,7 +5741,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 132
@@ -4998,7 +5773,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -5053,20 +5830,24 @@
                     "width": "420.79998779296875px",
                     "height": "304.8999938964844px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div>About This Example</div><div>-------------------</div><div>list-direction specifies how the list should be displayed when the given Part's layout property is set to \"list\". This property only has an effect when the layout is \"list\".</div><div>  </div><div>Possible values are:</div><div>* row - left to right</div><div>* column - top to bottom</div><div> </div><div>Use the toggle buttons above to see each property in action.</div><div>  </div><div>See other cards in this stack for other list layout related properties</div><div></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -5091,7 +5872,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 174
@@ -5122,20 +5906,24 @@
                     "width": "421.79998779296875px",
                     "height": "103.89999389648438px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><font size=\"7\" face=\"Crimson Pro\">list-direction</font></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -5160,7 +5948,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 174
@@ -5190,7 +5981,9 @@
                     "list-direction": "row",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5258,7 +6051,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 0, 0, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5322,7 +6117,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(0, 0, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5386,7 +6183,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(0, 128, 0, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5456,7 +6255,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -5484,7 +6293,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 174
@@ -5521,7 +6333,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -5549,7 +6371,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 174
@@ -5578,7 +6403,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -5633,20 +6460,24 @@
                     "width": "629.7999877929688px",
                     "height": "235.1999969482422px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div>About This Example</div><div>-------------------</div><div>The list-wrapping property describes whether or not a Part that has a list layout should \"wrap\" its subparts to the next row or column when the container becomes too small to hold them all in the dominant axis.</div><div>  </div><div>To see this in action, use the toggle buttons on this card, open a halo on the example Area, and adjust the size.</div><div><br></div><div>list-direction takes true or false as values.<br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -5671,7 +6502,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 220
@@ -5701,7 +6535,9 @@
                     "list-direction": "column",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5726,7 +6562,7 @@
                 "pinning": "",
                 "layout": "list",
                 "list-direction": "column",
-                "list-wrapping": false,
+                "list-wrapping": true,
                 "top-padding": null,
                 "right-padding": null,
                 "bottom-padding": null,
@@ -5770,7 +6606,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 0, 0, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5834,7 +6672,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(0, 128, 0, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5898,7 +6738,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(0, 0, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -5962,7 +6804,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 0, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
@@ -6032,7 +6876,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -6060,7 +6914,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 220
@@ -6072,7 +6929,7 @@
                 "contents": null,
                 "enabled": true,
                 "id": 265,
-                "name": "Turn list-wrapping on",
+                "name": "Turn list-wrapping off",
                 "rectangle": "0, 0, 0, 0",
                 "script": "on click\n\tif the \"list-wrapping\" of first area of this card is true\n\tthen\n\t\tset \"list-wrapping\" to false in first area of this card\n\t\tset \"name\" to (\"Turn list-wrapping on\")\n\telse\n\t\tset \"list-wrapping\" to true in first area of this card\n\t\tset \"name\" to \"Turn list-wrapping off\"\n\tend if\nend click",
                 "editorOpen": false,
@@ -6097,7 +6954,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -6125,7 +6992,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 220
@@ -6156,20 +7026,24 @@
                     "width": "409.79998779296875px",
                     "height": "115.19999694824219px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><font size=\"7\" face=\"Crimson Pro\">list-wrapping<br></font></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -6194,7 +7068,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 220
@@ -6223,7 +7100,9 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(255, 255, 255, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "marked": false,
@@ -6279,20 +7158,24 @@
                     "width": "478.3999938964844px",
                     "height": "113.39999389648438px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div><font size=\"7\" face=\"Crimson Pro\">Example: Progress Bar</font><br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -6317,7 +7200,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 282
@@ -6347,7 +7233,9 @@
                     "list-direction": "row",
                     "list-wrapping": false
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 50,
                 "stepping": false,
                 "background-transparency": 1,
@@ -6400,7 +7288,7 @@
                 "editorOpen": false,
                 "events": [],
                 "cssStyle": {
-                    "width": "79.02px",
+                    "width": "26.340000000000003px",
                     "height": "50px",
                     "opacity": 1,
                     "display": null,
@@ -6413,14 +7301,16 @@
                     "list-wrapping": false,
                     "backgroundColor": "rgba(0, 128, 0, 1)"
                 },
+                "cssTextStyle": {},
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "background-transparency": 1,
                 "background-color": "green",
                 "transparency": 1,
                 "hide": false,
-                "width": 79.02,
+                "width": 26.340000000000003,
                 "height": 50,
                 "top": 0,
                 "left": 0,
@@ -6483,7 +7373,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -6511,7 +7411,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 282
@@ -6548,7 +7451,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -6576,7 +7489,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 282
@@ -6613,7 +7529,17 @@
                     "color": "rgba(0, 0, 0, 1)",
                     "textStyle": "plain"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "selectedText": null,
@@ -6641,7 +7567,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 282
@@ -6672,20 +7601,24 @@
                     "width": "578.7999877929688px",
                     "height": "291.3999938964844px"
                 },
+                "cssTextStyle": {
+                    "textAlign": "left",
+                    "fontFamily": "default",
+                    "color": "rgba(0, 0, 0, 1)",
+                    "textStyle": "plain",
+                    "font-weight": "normal",
+                    "font-style": "normal",
+                    "fontSize": 15
+                },
                 "number": -1,
+                "target": null,
                 "stepTime": 500,
                 "stepping": false,
                 "mode": "viewing",
                 "innerHTML": "<div>About This Example</div><div>-------------------</div><div><br></div><div>Here we have used two Areas to construct a kind of progress bar.</div><div>The outer area wraps the inner (green) area in a list layout. The inner</div><div>area sets its horizontal-resizing to rigid, and uses its width property to</div><div>determine how much space to take up.</div><div>  </div><div>If you inspect the script of the outer area, you will see we've added</div><div>a custom command handler for setProgressPercentage, which takes an actual</div><div>percent integer and updates itself accordingly. For example, the step handler</div><div>in that same area will increment the progress bar by 1 percent.</div><div>  </div><div>Play with the script and the example buttons provided to see this in action.<br></div>",
-                "autoSelect": false,
-                "autoTab": false,
-                "lockText": false,
-                "showLines": false,
-                "dontWrap": false,
-                "multipleLines": false,
-                "scroll": 0,
-                "sharedText": false,
-                "wideMargins": false,
+                "targetRangeId": null,
+                "text": "",
+                "editable": true,
                 "background-transparency": 1,
                 "background-color": null,
                 "transparency": 1,
@@ -6710,7 +7643,10 @@
                 "text-font": "default",
                 "text-color": "rgba(0, 0, 0, 1)",
                 "text-transparency": 1,
-                "text-style": "plain"
+                "text-style": "plain",
+                "text-bold": false,
+                "text-italic": false,
+                "text-size": 15
             },
             "subparts": [],
             "ownerId": 282
@@ -6718,19 +7654,35 @@
         "world": {
             "type": "world",
             "id": "world",
-            "properties": [],
+            "properties": {
+                "contents": null,
+                "enabled": true,
+                "id": "world",
+                "name": "",
+                "rectangle": "0, 0, 0, 0",
+                "script": null,
+                "editorOpen": false,
+                "events": [],
+                "cssStyle": {},
+                "cssTextStyle": {},
+                "number": -1,
+                "target": null,
+                "stepTime": 500,
+                "stepping": false,
+                "current": 0
+            },
             "subparts": [
                 1
             ],
             "ownerId": null,
             "loadedStacks": [
                 1
-            ],
-            "currentStack": null
+            ]
         }
     },
     "currentCardId": 3,
     "currentStackId": 1
 }</script>
+
 
 </body></html>

--- a/js/objects/parts/Area.js
+++ b/js/objects/parts/Area.js
@@ -56,6 +56,12 @@ class Area extends Part {
             false
         );
         this.setupStyleProperties();
+        // part specific default style properties
+        this.partProperties.setPropertyNamed(
+            this,
+            'background-transparency',
+            0
+        );
     }
 
 

--- a/js/objects/parts/Button.js
+++ b/js/objects/parts/Button.js
@@ -49,14 +49,15 @@ class Button extends Part {
 
         // Styling
         addBasicStyleProps(this);
-        this.partProperties.setPropertyNamed(
-            this,
-            'background-color',
-            "rgba(255, 234, 149, 1)", // var(--palette-yellow)
-        );
         addPositioningStyleProps(this);
         addTextStyleProps(this);
         this.setupStyleProperties();
+        // part specific default style properties
+        this.partProperties.setPropertyNamed(
+            this,
+            'background-color',
+            "rgb(255, 234, 149)", // var(--palette-yellow)
+        );
 
     }
 

--- a/js/objects/parts/Drawing.js
+++ b/js/objects/parts/Drawing.js
@@ -25,6 +25,12 @@ class Drawing extends Part {
         addBasicStyleProps(this);
         addPositioningStyleProps(this);
         this.setupStyleProperties();
+        // part specific default style properties
+        this.partProperties.setPropertyNamed(
+            this,
+            'background-transparency',
+            0
+        );
 
         // We are using a distinct show-border
         // property to deal with being able to see

--- a/js/objects/parts/Field.js
+++ b/js/objects/parts/Field.js
@@ -102,6 +102,12 @@ class Field extends Part {
         addPositioningStyleProps(this);
         addTextStyleProps(this);
         this.setupStyleProperties();
+        // part specific default style properties
+        this.partProperties.setPropertyNamed(
+            this,
+            'background-color',
+            "rgb(255, 248, 220)", // var(--palette-cornsik)
+        );
 
         // Private command handlers
 

--- a/js/objects/parts/Window.js
+++ b/js/objects/parts/Window.js
@@ -55,6 +55,12 @@ class Window extends Part {
         addBasicStyleProps(this);
         addPositioningStyleProps(this);
         this.setupStyleProperties();
+        // part specific default style properties
+        this.partProperties.setPropertyNamed(
+            this,
+            'background-transparency',
+            0
+        );
 
         // Bind methods
         this.setTarget = this.setTarget.bind(this);

--- a/js/objects/tests/test-styling-with-preload.js
+++ b/js/objects/tests/test-styling-with-preload.js
@@ -24,8 +24,6 @@ describe('CSS Styler Util', () => {
         it('Text color conversion', () => {
             cssStyler(stylerObj, "text-color", "rgb(255, 0, 0)");
             assert.equal(stylerObj["color"], "rgba(255, 0, 0, 1)");
-            cssStyler(stylerObj, "text-color", "rgba(255, 0, 0, 1)");
-            assert.equal(stylerObj["color"], "rgba(255, 0, 0, 1)");
             cssStyler(stylerObj, "text-color", "red");
             assert.equal(stylerObj["color"], "rgba(255, 0, 0, 1)");
         });
@@ -34,6 +32,20 @@ describe('CSS Styler Util', () => {
             assert.equal(stylerObj["color"], "rgba(255, 0, 0, 0.5)");
             cssStyler(stylerObj, "text-transparency", ".5");
             assert.equal(stylerObj["color"], "rgba(255, 0, 0, .5)");
+        });
+    });
+    describe('Background', () => {
+        it('Background color conversion', () => {
+            cssStyler(stylerObj, "background-color", "rgb(0, 0, 0)");
+            assert.equal(stylerObj["backgroundColor"], "rgba(0, 0, 0, 1)");
+            cssStyler(stylerObj, "background-color", "red");
+            assert.equal(stylerObj["backgroundColor"], "rgba(255, 0, 0, 1)");
+        });
+        it('Background transparency', () => {
+            cssStyler(stylerObj, "background-transparency", .5);
+            assert.equal(stylerObj["backgroundColor"], "rgba(255, 0, 0, 0.5)");
+            cssStyler(stylerObj, "background-transparency", ".5");
+            assert.equal(stylerObj["backgroundColor"], "rgba(255, 0, 0, .5)");
         });
     });
     it('Transparency', () => {

--- a/js/objects/utils/styleProperties.js
+++ b/js/objects/utils/styleProperties.js
@@ -15,7 +15,7 @@ const addBasicStyleProps = (target) => {
     );
     target.partProperties.newStyleProp(
         'background-color',
-        "rgba(255, 255, 255)", // white 
+        "rgb(255, 255, 255)", // white 
     );
     target.partProperties.newStyleProp(
         'transparency',
@@ -214,7 +214,7 @@ const addTextStyleProps = (target) => {
     );
     target.partProperties.newStyleProp(
         'text-color',
-        "rgba(0, 0, 0)", // black
+        "rgb(0, 0, 0)", // black
         'cssTextStyle'
     );
     target.partProperties.newStyleProp(
@@ -257,7 +257,7 @@ const addLayoutStyleProps = (target) => {
     // list - Will force items into either a row
     // or column list, based on the pairing with
     // the 'listDirection' property
-    target.partProperties.newStyleProp(
+    target.partProperties.newBasicProp(
         'layout',
         'strict'
     );
@@ -265,14 +265,14 @@ const addLayoutStyleProps = (target) => {
     // list-direction specifies row or column
     // and will only have an effect whent the
     // layout property is set to 'list'
-    target.partProperties.newStyleProp(
+    target.partProperties.newBasicProp(
         'list-direction',
         'row'
     );
 
     // Wrapping specifies whether a list should
     // wrap along its dominant dimension (row or column)
-    target.partProperties.newStyleProp(
+    target.partProperties.newBasicProp(
         'list-wrapping',
         false
     );

--- a/js/objects/utils/styleProperties.js
+++ b/js/objects/utils/styleProperties.js
@@ -15,7 +15,7 @@ const addBasicStyleProps = (target) => {
     );
     target.partProperties.newStyleProp(
         'background-color',
-        null
+        "rgba(255, 255, 255)", // white 
     );
     target.partProperties.newStyleProp(
         'transparency',
@@ -73,7 +73,7 @@ const addPositioningStyleProps = (target) => {
         'horizontal-resizing',
         'rigid'
     );
-    
+
     // vertical-resizing specifies a strategy
     // for how this Part should adjust its
     // vertical axis relative to the parent.
@@ -214,7 +214,7 @@ const addTextStyleProps = (target) => {
     );
     target.partProperties.newStyleProp(
         'text-color',
-        "rgba(0, 0, 0, 1)", // black
+        "rgba(0, 0, 0)", // black
         'cssTextStyle'
     );
     target.partProperties.newStyleProp(

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -174,7 +174,7 @@ const _colorToRGBA = (cssColor, STColor) => {
         }
     }
     if(cssColor){
-        [_, _, _, a] = cssColor.match(/\d+/g);
+        [_, _, _, a] = cssColor.match(/[\d\.]+/g);
         // if Alpha is not defined then we set it to 1
         // default for browsers
     }

--- a/js/objects/utils/styler.js
+++ b/js/objects/utils/styler.js
@@ -15,16 +15,16 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
     switch(propertyName){
 
     case "background-color":
-        _setOrNot(styleObj, "backgroundColor",  _colorToRGBA(propertyValue));
+        _setOrNot(styleObj, "backgroundColor",  _colorToRGBA(styleObj["backgroundColor"], propertyValue));
         break;
 
     case "background-transparency":
         // here we set the Alpha value of the current styleObj["backgroundColor"] rgba
-        _setOrNot(styleObj, "backgroundColor",  _colorToRGBA(styleObj["backgroundColor"], propertyValue));
+        _setOrNot(styleObj, "backgroundColor",  _colorTransparencyToRGBA(styleObj["backgroundColor"], propertyValue));
         break;
 
     case "text-color":
-        _setOrNot(styleObj, "color",  _colorToRGBA(propertyValue));
+        _setOrNot(styleObj, "color",  _colorToRGBA(styleObj["color"], propertyValue));
         break;
 
     case "text-font":
@@ -69,7 +69,7 @@ const cssStyler = (styleObj, propertyName, propertyValue) => {
 
     case "text-transparency":
         // here we set the Alpha value of the current styleObj["color"] rgba
-        _setOrNot(styleObj, "color",  _colorToRGBA(styleObj["color"], propertyValue));
+        _setOrNot(styleObj, "color",  _colorTransparencyToRGBA(styleObj["color"], propertyValue));
         break;
 
     case "top":
@@ -154,36 +154,44 @@ const _intToPx = (n) => {
 };
 
 // Convert colors to rgba
-// If a color string is a referenced name from the list
-// below then use its RGB values. Else if the string is
-// of the form RGBA with A=1. If A is provided
-// convert and/or replace the current value of A with the
-// argument value.
-const _colorToRGBA = (color, A) => {
-    if(color == null || color === undefined){
+// change a css color RGB values, preserving the A(lpha) value
+const _colorToRGBA = (cssColor, STColor) => {
+    if(!STColor){
         return;
     }
-    let r, g, b, a;
-    // either RGB or RGBA is accepted
-    if(color.startsWith("rgb")){
-        [r, g, b, a] = color.match(/\d+/g);
+    let r, g, b, a, _;
+    // ST colors are RGB
+    if(STColor.startsWith("rgb")){
+        [r, g, b] = STColor.match(/\d+/g);
     } else {
-        let colorInfo = basicCSSColors[color];
+        let colorInfo = basicCSSColors[STColor];
         if(colorInfo){
             r = colorInfo["r"];
             g = colorInfo["g"];
             b = colorInfo["b"];
-            a = colorInfo["a"];
         } else {
             return;
         }
     }
-    if(A){
-        a = A;
-    } else if(a === undefined){
+    if(cssColor){
+        [_, _, _, a] = cssColor.match(/\d+/g);
+        // if Alpha is not defined then we set it to 1
+        // default for browsers
+    }
+    if(!a){
         a = 1;
     }
     return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+// change the A(alpha) value, preserving the RGB values
+const _colorTransparencyToRGBA = (cssColor, tValue) => {
+    if(!cssColor){
+        return;
+    }
+    let r, g, b;
+    [r, g, b] = cssColor.match(/\d+/g);
+    return `rgba(${r}, ${g}, ${b}, ${tValue})`;
 }
 
 // Add more colors as needed

--- a/js/objects/views/editors/EditorView.js
+++ b/js/objects/views/editors/EditorView.js
@@ -354,7 +354,7 @@ class EditorView extends HTMLElement {
     onColorSelected(event){
         let command = event.target.getAttribute("selector-command");
         let colorInfo = event.detail;
-        let colorStr = `rgba(${colorInfo.r}, ${colorInfo.g}, ${colorInfo.b}, ${colorInfo.alpha})`;
+        let colorStr = `rgb(${colorInfo.r}, ${colorInfo.g}, ${colorInfo.b})`;
         this.setProperty(command, colorStr);
     }
 


### PR DESCRIPTION
### Main Points ###

This PR fixes up two things: 

- a somewhat subtle bug in how we were dealing with color and transparency to RGBA css value conversion. Now ST color is RGB (no Alpha) value, or predefined keywords ("black" "red" etc), transparency is a float between 0 and 1, and these convert directly to RGBA css values. IE we map ST RGB -> css RGB, and ST transparency float -> css A. This allows us to preserve the transparency when changing the color on the part view, and fixes a number of other bugs we've see. 

- sets up default style properties which were not set before, like `background-color` and `transparency`. Now everything has a default `background-color` (white) which I think is fine since this is also true in the browser, and ensures that there is always a RGBA value in the `cssStyle` property which we need for the above. 

Note: I've set the default `transparency` for `st-area` to 0, which is inline with what we were seeing before (`st-area.background-color` was set to transparent in core.css), ie if you want to set the background-color you also need to set the transparency to something other than 0 or you won't see anything. The only reason this was not the behavior before was b/c of the bug fixed here. 

I've updated the bootstrap.html and layout-examples.html files to reflect these new changes. 

This PR closes #158