### PR TITLE
Navigator Fixes and Revisions

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -23,8 +23,8 @@
     --container-default-height: 15vh;
     --drawing-default-width: 500px;
     --drawing-default-height: 300px;
-    --field-default-width: 40vw;
-    --field-default-height: 30vh;
+    --field-default-width: 300px;
+    --field-default-height: 200px;
 }
 
 /* Keyframe Animations */
@@ -41,8 +41,7 @@
 
 body {
     display: block;
-    width: 100vw;
-    height: 100vh;
+    position: relative;
     overflow: hidden;
     font-family: "Crimson Pro";
     background-color: purple;
@@ -55,7 +54,11 @@ body {
 /* =World Styles
  *----------------------------------------------------*/
 st-world {
-    visibility: hidden;
+    display: block;
+    position: absolute;
+    overflow: hidden;
+    width: 100vw;
+    height: 100vh;
 }
 
 
@@ -173,6 +176,7 @@ st-field {
     height: var(--field-default-height);
     background-color: var(--palette-cornsik);
     position: absolute;
+    display: block;
 }
 
 /* =Layout Class Styles

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -92,10 +92,6 @@ const System = {
                 });
         } else {
             this.loadFromEmpty();
-            System.navigator.setModel(
-                System.partsById['world']
-            );
-            this.sendInitialOpenMessages();
         }
 
         // Attach a new clipboard instance
@@ -135,6 +131,11 @@ const System = {
         );
         // Update serialization
         this.serialize();
+
+        this.sendInitialOpenMessages();
+        System.navigator.setModel(
+            System.partsById['world']
+        );
     },
 
     sendInitialOpenMessages: function(){

--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -651,9 +651,14 @@ const System = {
     getFullHTMLString: function(){
         let clonedDocument = document.cloneNode(true);
         let world = clonedDocument.querySelector('st-world');
+        let nav = clonedDocument.querySelector('st-navigator');
         if(world){
             world.remove();
         }
+        if(nav){
+            nav.remove();
+        }
+        
         return clonedDocument.documentElement.outerHTML;
     },
 

--- a/js/objects/tests/test-audio-with-preload.js
+++ b/js/objects/tests/test-audio-with-preload.js
@@ -24,14 +24,15 @@ describe('Audio Part & View Tests', () => {
             assert.exists(currentCard.model);
         });
         it('Can add audio model+view to current card (via message)', () => {
-            let currentCard = document.querySelector('st-card.current-card');
+            let currentCard = document.querySelector('st-world st-card.current-card');
+            assert.exists(currentCard.model);
             let msg = {
                 type: "command",
                 commandName: "newModel",
                 args: ["audio", currentCard.model.id]
             };
             currentCard.sendMessage(msg, currentCard.model);
-            let audio = document.querySelector('st-card.current-card > st-audio');
+            let audio = currentCard.querySelector('st-audio');
             assert.exists(audio);
             assert.exists(audio.model);
         });

--- a/js/objects/tests/test-button-system-commands-with-preload.js
+++ b/js/objects/tests/test-button-system-commands-with-preload.js
@@ -30,7 +30,7 @@ describe('Button System Command Tests', () => {
             assert.exists(foundEl.model);
         });
         it('Can get card view by its id', () => {
-            let cardEl = document.querySelector('st-card.current-card');
+            let cardEl = document.querySelector('st-world st-card.current-card');
             let id = cardEl.getAttribute('part-id');
             let found = document.querySelector(`[part-id="${id}"]`);
             assert.equal(id, "2");

--- a/js/objects/tests/test-system-with-preload.js
+++ b/js/objects/tests/test-system-with-preload.js
@@ -11,10 +11,10 @@ const expect = chai.expect;
 
 describe('System methods', () => {
     it('Can setup world with a multi-stack multi-card stack', () => {
-        let currentStackViews = document.querySelectorAll('st-stack.current-stack');
+        let currentStackViews = document.querySelectorAll('st-world st-stack.current-stack');
         assert.equal(currentStackViews.length, 1);
         let currentStackModel = currentStackViews[0].model;
-        let cardViews = document.querySelectorAll('st-stack.current-stack > st-card');
+        let cardViews = document.querySelectorAll('st-world st-stack.current-stack > st-card');
         assert.equal(cardViews.length, 1);
         // add a few more cards
         let newCardMsg = {
@@ -24,9 +24,9 @@ describe('System methods', () => {
         };
         System.receiveMessage(newCardMsg);
         System.receiveMessage(newCardMsg);
-        cardViews = document.querySelectorAll('st-stack.current-stack > st-card');
+        cardViews = document.querySelectorAll('st-world st-stack.current-stack > st-card');
         assert.equal(cardViews.length, 3);
-        let currentCardViews = document.querySelectorAll('st-stack.current-stack > st-card.current-card');
+        let currentCardViews = document.querySelectorAll('st-world st-stack.current-stack > st-card.current-card');
         assert.equal(currentCardViews.length, 1);
         // add a few more stacks
         let worldView = document.querySelector('st-world');

--- a/js/objects/tests/test-views-lifecycle-with-preload.js
+++ b/js/objects/tests/test-views-lifecycle-with-preload.js
@@ -10,10 +10,10 @@ const expect = chai.expect;
 
 describe('Button Views', () => {
     it('Can setup world with a stack, card and button', () => {
-        let currentStackViews = document.querySelectorAll('st-stack.current-stack');
+        let currentStackViews = document.querySelectorAll('st-world st-stack.current-stack');
         assert.equal(currentStackViews.length, 1);
         let currentStackModel = currentStackViews[0].model;
-        let cardViews = document.querySelectorAll('st-stack.current-stack > st-card');
+        let cardViews = document.querySelectorAll('st-world st-stack.current-stack > st-card');
         assert.equal(cardViews.length, 1);
         let currentCardModel = cardViews[0].model;
         // add a named button
@@ -27,7 +27,7 @@ describe('Button Views', () => {
         assert.equal(buttonViews.length, 1);
     });
     it('Button has the proper name (ButtonView..afterConnected() was called)', () => {
-        let cardView = document.querySelector('st-stack.current-stack > st-card');
+        let cardView = document.querySelector('st-world st-stack.current-stack > st-card');
         let buttonView = cardView.querySelector('st-button');
         assert.equal("New Button", buttonView.innerText);
     });

--- a/js/objects/utils/clipboard.js
+++ b/js/objects/utils/clipboard.js
@@ -59,6 +59,31 @@ class STClipboard {
                     
                     // Open Halo on the new view
                     deserializer.rootViews[0].openHalo();
+
+                    // Dispatch the CustomEvent that notifies listeners
+                    // that a new view was added (used by Nav etc)
+                    let event = new CustomEvent('st-view-added', {
+                        detail: {
+                            partType: newPart.type,
+                            partId: newPart.id,
+                            ownerId: newPart._owner.id
+                        }
+                    });
+                    deserializer.rootViews[0].dispatchEvent(event);
+
+                    // Add any lensed views that might be needed
+                    let rootLensViews = this.system.findLensViewsById(newPart._owner.id);
+                    rootLensViews.forEach(lensView => {
+                        let newLensView = document.createElement(
+                            this.system.tagNameForViewNamed(newPart.type)
+                        );
+                        newLensView.setModel(newPart);
+                        newLensView.removeAttribute('part-id');
+                        newLensView.setAttribute('lens-part-id', newPart.id);
+                        newLensView.setAttribute('role', 'lens');
+                        lensView.appendChild(newLensView);
+                    });
+                    
                     return;
                 })
                 .catch(err => {

--- a/js/objects/views/FieldView.js
+++ b/js/objects/views/FieldView.js
@@ -150,8 +150,6 @@ class FieldView extends PartView {
 
         this.textarea.addEventListener('input', this.onInput);
         this.textarea.addEventListener('keydown', this.onKeydown);
-        this.textarea.focus();
-        // document.execCommand("defaultParagraphSeparator", false, "br");
         // No need to add a click listener as the base PartView class does that
     }
 

--- a/js/objects/views/WorldView.js
+++ b/js/objects/views/WorldView.js
@@ -74,7 +74,6 @@ class WorldView extends PartView {
 
     handleKeyDown(event){
         if(event.altKey && event.ctrlKey && event.code == "Space"){
-            console.log('nav toggle');
             let navigator = document.querySelector('st-navigator');
             navigator.toggle();
         }

--- a/js/objects/views/navigator/CardRow.js
+++ b/js/objects/views/navigator/CardRow.js
@@ -39,7 +39,6 @@ class CardRow extends PartView {
         this.handlePartAdded = this.handlePartAdded.bind(this);
         this.showInitially = this.showInitially.bind(this);
         this.onWrapperClick = this.onWrapperClick.bind(this);
-        this._recursivelyUpdateLensViewSubparts = this._recursivelyUpdateLensViewSubparts.bind(this);
     }
 
     afterModelSet(){
@@ -64,16 +63,13 @@ class CardRow extends PartView {
         if(!this.model.currentCard){
             return;
         }
-        let currentId = this.model.currentCard.id;
-        let wrappedViews = Array.from(
-            this.querySelectorAll('wrapped-view')
-        );
-        wrappedViews.forEach(wrappedView => {
-            let wrappedChild = wrappedView.children[0];
-            if(wrappedChild.model.id == currentId){
-                wrappedView.classList.add('current');
+        let wrappers = Array.from(this.querySelectorAll('wrapped-view'));
+        wrappers.forEach(wrapper => {
+            let wrappedId = wrapper.getAttribute('wrapped-id');
+            if(wrappedId == this.model.currentCard.id.toString()){
+                wrapper.classList.add('current');
             } else {
-                wrappedView.classList.remove('current');
+                wrapper.classList.remove('current');
             }
         });
     }
@@ -116,60 +112,16 @@ class CardRow extends PartView {
     }
 
     showInitially(){
-        let wrappers = Array.from(this.querySelectorAll('wrapped-view'));
-        let delay = 100;
-        for(let i = 0; i < wrappers.length; i++){
-            let wrapper = wrappers[i];
-            setTimeout(() => {
-                wrapper.classList.remove('hide');
-            }, delay * (i + 1));
-            setTimeout(() => {
-                wrapper.showContent();
-            }, delay * (i + 2));
-        }
+        // Nothing for now
     }
 
     addWrappedCard(aCard){
-        // Create a lensed copy of the CardView
-        let cardView = document.querySelector(`[part-id="${aCard.id}"]`);
-        let cardLensView = cardView.cloneNode(true);
-        cardLensView.setAttribute('lens-part-id', aCard.id);
-        cardLensView.setAttribute('slot', 'wrapped-view');
-        cardLensView.style.pointerEvents = "none";
-
-        // The wrapper will handle current-ness, so remove
-        // the class from the lensed version
-        cardLensView.classList.remove('current-card');
-
-        // Recursively create lens views of all subpart
-        // children and append them in the correct places
-        cardLensView.isLensed = true;
-        cardLensView.setModel(aCard);
-        cardLensView.removeAttribute('part-id');
-        this._recursivelyUpdateLensViewSubparts(cardLensView, aCard.id);
-
         // Insert the lensed CardView into the wrapper
         let wrapper = document.createElement('wrapped-view');
         wrapper.setAttribute('slot', 'cards');
-        wrapper.setAttribute('wrapped-id', aCard.id);
         wrapper.addEventListener('click', this.onWrapperClick);
-        wrapper.appendChild(cardLensView);
-        wrapper.hideContent();
-        wrapper.classList.add('hide');
         this.appendChild(wrapper);
-    }
-
-    _recursivelyUpdateLensViewSubparts(aLensView, aLensId){
-        let subViews = Array.from(aLensView.children);
-        subViews.forEach(subView => {
-            subView.isLensed = true;
-            let id = subView.getAttribute('part-id');
-            subView.setAttribute('lens-part-id', id);
-            let model = window.System.partsById[id];
-            subView.setModel(model);
-            subView.removeAttribute('part-id');
-            this._recursivelyUpdateLensViewSubparts(subView, id);
-        });
+        wrapper.setModel(aCard);
     }
 };
 

--- a/js/objects/views/navigator/Navigator.js
+++ b/js/objects/views/navigator/Navigator.js
@@ -75,14 +75,16 @@ const templateString = `
         box-sizing: border-box;
         position: absolute;
         width: 100%;
-        top: 100%;
+        bottom: 0;
         min-height: 271px;
         background-color: white;
         backdrop-filter: blur(4px);
-        transition: top 0.2s ease-out;
+        transition: transform 0.2s ease-out;
         padding: 20px;
+        transform: translateY(100%);
         border-top: 1px solid rgba(50, 50, 50, 0.4);
         overflow-y: hidden;
+        overflow-x: auto;
         z-index: 1000;
     }
 
@@ -160,6 +162,11 @@ class STNavigator extends PartView {
         }).forEach(stackPart => {
             this.createCardRowFor(stackPart);
         });
+
+        // Init the StackRow
+        this.stackRowEl.initView();
+        
+        // Update the current card/stack values
         this.handleCurrentChange();
 
         // Respond to eventual current-ness prop
@@ -211,17 +218,11 @@ class STNavigator extends PartView {
     }
 
     open(){
-        if(!this.initialized && this.model){
-            this.stackRowEl.initView();
-            this.initialized = true;
-        }
-        let height = this.getBoundingClientRect().height;
-        let heightPx = `calc(100% - ${height}px)`;
-        this.style.top = heightPx;
+        this.style.transform = "translateY(0)";
     }
 
     close(){
-        this.style.top = null;
+        this.style.transform = "translateY(100%)";
     }
 
     

--- a/js/objects/views/navigator/StackRow.js
+++ b/js/objects/views/navigator/StackRow.js
@@ -39,7 +39,6 @@ class StackRow extends PartView {
         this.handlePartAdded = this.handlePartAdded.bind(this);
         this.showInitially = this.showInitially.bind(this);
         this.onWrapperClick = this.onWrapperClick.bind(this);
-        this._recursivelyUpdateLensViewSubparts = this._recursivelyUpdateLensViewSubparts.bind(this);
     }
 
     afterModelSet(){
@@ -65,12 +64,12 @@ class StackRow extends PartView {
         let wrappedViews = Array.from(
             this.querySelectorAll('wrapped-view')
         );
-        wrappedViews.forEach(wrappedView => {
-            let wrappedChild = wrappedView.children[0];
-            if(wrappedChild.model.id == currentId){
-                wrappedView.classList.add('current');
+        wrappedViews.forEach(wrapper => {
+            let wrappedId = wrapper.getAttribute('wrapped-id');
+            if(wrappedId == this.model.currentStack.id.toString()){
+                wrapper.classList.add('current');
             } else {
-                wrappedView.classList.remove('current');
+                wrapper.classList.remove('current');
             }
         });
     }
@@ -96,6 +95,9 @@ class StackRow extends PartView {
     }
 
     initView(){
+        // Remove any existing wrapped views
+        this.innerHTML = "";
+
         // We iterate over each corresponding Stack and:
         // * Create a clone of its view node;
         // * Attach the correct model;
@@ -112,51 +114,16 @@ class StackRow extends PartView {
     }
 
     showInitially(){
-        let wrappers = Array.from(this.querySelectorAll('wrapped-view'));
-        wrappers.forEach(wrapper => {
-            wrapper.classList.remove('hide');
-            wrapper.showContent();
-        });
+        // Nothing for now
     }
 
-    addWrappedStack(aStack){
-        // Create a lensed copy of the StackView
-        let stackView = document.querySelector(`[part-id="${aStack.id}"]`);
-        let stackLensView = stackView.cloneNode(true);
-        stackLensView.setAttribute('lens-part-id', aStack.id);
-        stackLensView.setAttribute('slot', 'wrapped-view');
-        stackLensView.style.pointerEvents = "none";
-
-        // Recursively create lens views of all subpart children
-        // and append them in the correct places
-        stackLensView.isLensed = true;
-        stackLensView.setModel(aStack);
-        stackLensView.removeAttribute('part-id');
-        stackLensView.handleCurrentChange();
-        this._recursivelyUpdateLensViewSubparts(stackLensView, aStack.id);
-        
+    addWrappedStack(aStack){  
         // Insert the lensed StackView into the wrapper
         let wrapper = document.createElement('wrapped-view');
         wrapper.setAttribute("slot", "stacks");
-        wrapper.setAttribute("wrapped-id", aStack.id);
         wrapper.addEventListener('click', this.onWrapperClick);
-        wrapper.appendChild(stackLensView);
-        wrapper.hideContent();
-        wrapper.classList.add('hide');
         this.appendChild(wrapper);
-    }
-
-    _recursivelyUpdateLensViewSubparts(aLensView, aLensId){
-        let subViews = Array.from(aLensView.children);
-        subViews.forEach(subView => {
-            subView.isLensed = true;
-            let id = subView.getAttribute('part-id');
-            subView.setAttribute('lens-part-id', id);
-            let model = window.System.partsById[id];
-            subView.setModel(model);
-            subView.removeAttribute('part-id');
-            this._recursivelyUpdateLensViewSubparts(subView, id);
-        });
+        wrapper.setModel(aStack);
     }
 };
 

--- a/js/objects/views/navigator/WrappedView.js
+++ b/js/objects/views/navigator/WrappedView.js
@@ -63,6 +63,7 @@ const templateString = `
     #number-display > span {
         transform: translateY(-10px);
         transition: transform 0.2s linear;
+        pointer-events: none;
     }
 
     :host(:not(.current)) > #number-display {
@@ -168,6 +169,7 @@ class WrappedView extends PartView {
         lensedView.setAttribute('lens-part-id', aPartModel.id);
         lensedView.setAttribute('slot', 'wrapped-view');
         lensedView.style.pointerEvents = "none";
+        lensedView.wantsHalo = false;
 
         // Inline the initial scaling style properties.
         // We begin with an extremely small amount which will
@@ -195,6 +197,7 @@ class WrappedView extends PartView {
         let subViews = Array.from(lensedView.children);
         subViews.forEach(subView => {
             subView.isLensed = true;
+            subView.wantsHalo = false;
             let subId = subView.getAttribute('part-id');
             subView.setAttribute('lens-part-id', subId);
             let model = window.System.partsById[subId];
@@ -210,6 +213,10 @@ class WrappedView extends PartView {
     }
 
     styleTextCSS(){
+        // Do nothing
+    }
+
+    layoutChanged(){
         // Do nothing
     }
 };


### PR DESCRIPTION
## What ##
This PR fixes display and logic bugginess in the Navigator.
  
## Problems ##
There were several cascading problems, partially identified in #179  and #180, that were causing Navigator to completely bug-out and at times freeze the whole system.
  
There were a few things going on. First, flipping back and forth quickly between two Stacks with the Nav open could lead to display bugs. This is because the CardRow for each Stack was being composed and re-rendered on the fly each time, meaning a whole tree of elements was being copied, inserted, and having its model set (recursively) each time we switched between stacks.
  
The "layout pushes up" issue was a fairly arcane one. It only applied to `FieldView` and no other parts. It turns out that `FieldView` sets its element focus when it is attached to the DOM. Because the Navigator's "lensed views" are just PartView elements with the same model attached, the browser was attempting to focus the tiny, scaled-down field in the Nav, meaning it would scroll (without scrollbars) to that element to get it within the viewport. This is why things seemed to "push up"
  
## Fixes and Improvements ##
### `WrappedView` is now a PartView ###
Previously, WrappedView was simply a custom webcomponent that had no strict relation to the rest of the SimpleTalk system. But now we've made the better decision to make it a PartView subclass, meaning it can accept a model and has all the lifecycle methods we would expect from a normal PartView.
  
Instead of waiting for some user action or for the right DOM to be set, the nested "lensed" trees will be created whenever the model is set on a WrappedView. This is also when the scaling of the view will occur. Consequently, "currentness" can now apply to the WrappedView as well, where needed.
  
### Optimizing CardRow Rendering ###
As mentioned, we were re-rendering the CardRow WrappedViews each time we switched between Stacks. That's a lot of computation to happen if you are toggling back and forth quickly. The main Navigator PartView will now pre-render all CardRows for any Stack that is loaded into the System, showing only the CardRow that is mapped to the current stack.
  
The latter process is interesting: we simply set the `slot=` attribute on the `<nav-card-row>` (a CardRow instance) that maps to the current stack, and we remove that attribute on all others. This results in an instant swapping, since CardRow must be specifically slotted in Navigator's shadow dom.
  
### The "pushing-up" issue ###
The solution here was crude but effective: remove the line where FieldView automatically gets the focus whenever it is attached to the DOM. We definitely don't want fields inside of the nav trying to get the focus. There might be a better way down the road to ensure that the main FieldViews do get the focus that we want while ensuring that WrappedView copies are not affected. TBD.
  
Toggling should now happen quickly and without bugginess.
  
### Other Fixes ###
I've added some minor styling fixes here and there. For example, Cards that make use of a list-layout on themselves should now display correctly in the Nav WrappedViews.
  
## What To Do ##
Steps to really put the Navigator through the ringer:
1. Load the layout stack and click through cards. Toggle nav with Ctrl+Alt+Space and really try to break it.
2. Load another stack using `importWorld "layout-examples.html"` or whatever stack you want. Note that at this point in the branching any stack with a Drawing in it will not load properly
  
## Tests ##
We had to update some querySelectors in a few tests. These selectors assumed only a single stack/card tree existing in the document. But with Nav we can have copies of stacks and cards inside of the navigator. Some of the tests were pulling out the copies and not the main views to be tested. The solution is to prepend `st-world` to any relevant querySelector, which will then not include anything in the navigator.
  
## Closes ##
#179 
#180 