### PR TITLE
Window resize

### DIFF
--- a/js/objects/views/WindowView.js
+++ b/js/objects/views/WindowView.js
@@ -247,17 +247,15 @@ class WindowView extends PartView {
     onGripMove(event){
         if(this.isGripping){
             // Figure out the current width and height.
-            // For Windows, the grip will actually be adjusting
-            // the underlying StackView's minHeight/minWidth
-            let view = this.querySelector('st-stack');
-            let box = view.getBoundingClientRect();
+            // and set the property to the new one
+            let box = this.getBoundingClientRect();
             let newWidth = Math.floor(box.width) + event.movementX;
             if(newWidth){
-                view.style.width = `${newWidth}px`;
+                this.model.partProperties.setPropertyNamed(this.model, "width", newWidth);
             }
             let newHeight = Math.floor(box.height) + event.movementY;
             if(newHeight){
-                view.style.height = `${newHeight}px`;
+                this.model.partProperties.setPropertyNamed(this.model, "height", newHeight);
             }
         }
     }


### PR DESCRIPTION
### Main Points ###

This PR updates how `st-window` resizes. Before it was directly setting the width/height inline styles on its stack subpart, which was an early solution before we had style properties. The issue is that this prevented window state from being property serialized and from being updated/seen in the navigator (I.e. adjusting the size of the window would not be reflected in the nav). 

Now window updates its width/height props. 


**NOTE**  Updating the window size and then opening the navigator throws the following error: 

![image](https://user-images.githubusercontent.com/1154326/114705903-92ad0f80-9d28-11eb-9ed6-5770f4a9821e.png)



This might all be fixed with #183 or this might be due to the version of the serialization for the example files coming from #184 

regardless we should be weary and potentially merge this in before #183 or rebase the latter on top of it to test. 