### PR TITLE
[bugfix] Fix hand position smoothing computation

### DIFF
--- a/js/objects/utils/handInterface.js
+++ b/js/objects/utils/handInterface.js
@@ -59,7 +59,7 @@ const detectHands = async () => {
     const vw = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0)
     const vh = Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
     const p = [0.5 * (x1 + x2) * vw, 0.5 * (y1 + y2) * vh];
-    handInterface.positions = [].concat(handInterface.positions.slice(-2), p);
+    handInterface.positions = [].concat(handInterface.positions.slice(-2), [p]);
     var target = handInterface.targetElement;
     if (target === null) {
         target = handInterface.leninHand;


### PR DESCRIPTION
A bug as introduced in commit 6c09655e which introduced hand smoothing computations. I have no clue how this happened since I had previously tested this and used it. The only explanation is that I screwed up a merge or something and didn't realize that my change messed things up and then just stopped looking at the hand stuff for a while.

Anyway the fix is tiny and trivial so there's that...