### PR TITLE
Serialization / Drawing Fixes

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -161,49 +161,6 @@ const System = {
         }, world.currentStack.currentCard);
     },
 
-
-    // returns a recursive tree structure, specified by a parent NODE
-    // where a NODE has the form {id: ID, type: TYPE, children: [NODES]}
-    buildSimpleTree: function(partsById, node) {
-        var part = partsById[node.id];
-
-        var children = part.subparts.map(spart => {
-            return {id: spart.id, type: spart.type};
-        });
-
-        return {...node, children: children.map(child => this.buildSimpleTree(partsById, child))};
-    },
-
-    passDevToolMessage: function(aMessage, source, target){
-        // TODO: in the future, we'd likely pass some more complete "state" through to the
-        // debug tool.  But for now, the tree result 
-        var simpleTree = this.buildSimpleTree(this.partsById, {id: 'world', type: 'World'});
-        let messageData = {
-            msg: aMessage,
-            source: {
-                name: source.name,
-                id: source.id,
-            },
-            target: {
-                name: target.name,
-                id: target.id,
-            },
-            tree: simpleTree,
-        };
-
-        // if we don't have an origin we are running at test
-        // can return the string "null"
-        if (window.location.origin !== null && window.location.origin !== "null"){
-            try{
-                window.postMessage(messageData, window.location.origin);
-            } catch(error){
-                console.log("failed to postMessage to devtool: ");
-                console.log(messageData);
-            }
-        }
-        this.messageLog.push(messageData);
-    },
-
     sendMessage: function(aMessage, source, target){
         if(!target || target == undefined){
             throw new Error('Messages must be sent with target receivers specified!');
@@ -218,7 +175,6 @@ const System = {
             id: source.id,
         });
 
-        // this.passDevToolMessage(aMessage, source, target);
         return target.receiveMessage(aMessage);
     },
 

--- a/js/objects/views/navigator/WrappedView.js
+++ b/js/objects/views/navigator/WrappedView.js
@@ -194,7 +194,9 @@ class WrappedView extends PartView {
     }
 
     _recursivelyUpdateLensViews(lensedView, anId){
-        let subViews = Array.from(lensedView.children);
+        let subViews = Array.from(lensedView.children).filter(child => {
+            return child.isPartView;
+        });
         subViews.forEach(subView => {
             subView.isLensed = true;
             subView.wantsHalo = false;


### PR DESCRIPTION
## What ##
This PR implements a couple of quick fixes to issues that were breaking serialization/deserialization.
  
The first was that the devtool was interfering with deserialized Drawings, because the Drawing part sends messages when its image part property is set and devtool was expecting a world to already exist when intercepting all messages.
  
The second is that the Nav had certain expectations of lensed PartViews that was not always consistent.
  
Both of these have been fixed with easy changes. See the commit comments for more information.
  
## How to Test ##
Try serializing anything with drawings in it and re-opening. Additionally, try importing stacks that have Drawings, like mandate.

## Closes ##
#173
#177 