### PR TITLE
Interactive Targeting v1

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -343,7 +343,8 @@ wrapped-view > st-stack {
     background-color: red;
 }
 
-body.targeting-mode {
+body.targeting-mode,
+body.targeting-mode [part-id] {
     cursor: crosshair !important;
 }
 

--- a/css/core.css
+++ b/css/core.css
@@ -332,6 +332,21 @@ wrapped-view > st-stack {
     outline: solid 1px var(--palette-orange);
 }
 
+.targeting:after {
+    content: " ";
+    display: block;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: red;
+}
+
+body.targeting-mode {
+    cursor: crosshair !important;
+}
+
 
 /* = TESTING: TODO: Remove
  * --------------------------------------------------*/

--- a/js/objects/views/Halo.js
+++ b/js/objects/views/Halo.js
@@ -50,6 +50,14 @@ const pasteIcon = `
 </svg>
 `;
 
+const targetIcon = `
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-focus" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+   <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+   <circle cx="12" cy="12" r=".5" fill="currentColor"></circle>
+   <circle cx="12" cy="12" r="9"></circle>
+</svg>
+`;
+
 const templateString = `
 <style>
  :host {
@@ -160,6 +168,9 @@ const templateString = `
     <div id="halo-paste" class="halo-button" title="Paste the contents of clipboard into this Part">
         ${pasteIcon}
     </div>
+    <div id="halo-target" class="halo-button" title="Select this Part's target">
+        ${targetIcon}
+    </div>
     <slot name="left-column"></slot>
 </div>
 
@@ -234,6 +245,10 @@ class Halo extends HTMLElement {
             // Paste button
             this.paster = this.shadowRoot.getElementById('halo-paste');
             this.paster.addEventListener('click', this.targetElement.onHaloPaste);
+
+            // Target button
+            this.targeter = this.shadowRoot.getElementById('halo-target');
+            this.targeter.addEventListener('click', this.targetElement.onHaloTarget);
         }
     }
 

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -587,7 +587,7 @@ class PartView extends HTMLElement {
         let currentStackView = document.querySelector(`[part-id="${window.System.world.currentStack.id}"]`);
         let currentCardView = document.querySelector(`[part-id="${window.System.world.currentStack.currentCard.id}"]`);
         let targetCardParts = Array.from(currentCardView.querySelectorAll('[part-id]'));
-        let targetStackParts = Array.from(currentStackView.querySelectorAll('[part-id]:not(st-card, st-stack)'));
+        let targetStackParts = Array.from(currentStackView.querySelectorAll('[part-id]:not(st-card):not(st-stack)'));
         let allTargets = targetCardParts.concat(targetStackParts);
         allTargets.forEach(partView => {
             document.addEventListener('keydown', this.handleTargetKey);
@@ -606,7 +606,7 @@ class PartView extends HTMLElement {
         let currentStackView = document.querySelector(`[part-id="${window.System.world.currentStack.id}"]`);
         let currentCardView = document.querySelector(`[part-id="${window.System.world.currentStack.currentCard.id}"]`);
         let targetCardParts = Array.from(currentCardView.querySelectorAll('[part-id]'));
-        let targetStackParts = Array.from(currentStackView.querySelectorAll('[part-id]:not(st-card, st-stack)'));
+        let targetStackParts = Array.from(currentStackView.querySelectorAll('[part-id]:not(st-card):not(st-stack)'));
         let allTargets = targetCardParts.concat(targetStackParts);
         allTargets.forEach(partView => {
             document.removeEventListener('keydown', this.handleTargetKey);

--- a/js/objects/views/PartView.js
+++ b/js/objects/views/PartView.js
@@ -584,7 +584,6 @@ class PartView extends HTMLElement {
     onHaloTarget(event){
         // Add targeting receive listeners to all PartViews
         // on the current card.
-        console.log('calling onHaloTarget');
         let currentStackView = document.querySelector(`[part-id="${window.System.world.currentStack.id}"]`);
         let currentCardView = document.querySelector(`[part-id="${window.System.world.currentStack.currentCard.id}"]`);
         let targetCardParts = Array.from(currentCardView.querySelectorAll('[part-id]'));
@@ -604,7 +603,6 @@ class PartView extends HTMLElement {
         // Remove all targeting related event listeners
         // that were added during the onHaloTarget
         // handler
-        console.log('calling endHaloTarget');
         let currentStackView = document.querySelector(`[part-id="${window.System.world.currentStack.id}"]`);
         let currentCardView = document.querySelector(`[part-id="${window.System.world.currentStack.currentCard.id}"]`);
         let targetCardParts = Array.from(currentCardView.querySelectorAll('[part-id]'));
@@ -621,28 +619,27 @@ class PartView extends HTMLElement {
     }
 
     handleTargetKey(event){
-        console.log('targeting keypress');
         if(event.key == 'Escape'){
-            console.log('Escape');
             this.endHaloTarget();
         }
     }
 
     handleTargetMouseOver(event){
-        console.log(event.target);
-        event.target.classList.add('targeting');
+        if(!event.target.classList.contains('targeting')){
+            event.target.classList.add('targeting');
+            event.target['onclick'] = null;
+        }
     }
 
     handleTargetMouseLeave(event){
-        console.log(event.target);
-        event.target.classList.remove('targeting');
+        if(event.target.classList.contains('targeting')){
+            event.target.classList.remove('targeting');
+            event.target['onclick'] = event.target.onClick;
+        }
     }
 
     handleTargetMouseClick(event){
-        console.log('target click');
         event.target.classList.remove('targeting');
-        alert(event.target.model.id);
-        event.stopPropagation();
         event.preventDefault();
         this.model.partProperties.setPropertyNamed(
             this.model,
@@ -650,6 +647,8 @@ class PartView extends HTMLElement {
             event.target.model.id
         );
         this.endHaloTarget();
+        event.stopImmediatePropagation();
+        event.target.onclick = event.target.onClick;
     }
 
     onAuxClick(event){


### PR DESCRIPTION
## What ##
This PR implements a new Halo button and mode of interaction that allows us to visually and interactively set the target of one part to be another part.
  
## Implementation ##
### How to do it ###
The Halo now has a "target" button. Click this will put the system into "target mode," as indicated by the crosshair cursor. Hovering over any other visible part will turn that part red, indicating that you can click it to establish it as the target part. If you wish to cancel targeting mode, hit the escape key.
  
Once established, the correct value will be set in the original Part's `target` property and can be used as normal.
  
### Halo Targeting Handlers ###
The implementation includes several handlers and methods on `PartView` that Halo will call in order to toggle targeting mode. Most of the interaction deals with adding and removing handlers, in particular enter, leave, and click events. Note that in targeting mode, mouse enter will remove the default click event and mouseleave will add it back. This is to prevent the original click action from triggering (on buttons, for example) when binding the element as a target.
  
## Testing ##
We need to just test this ourselves since there is so much complex mouse interaction. So far it's working well, even if it's a bit ugly.