### PR TITLE
Write out serialization in pretty print format

### DIFF
--- a/js/objects/System.js
+++ b/js/objects/System.js
@@ -586,7 +586,7 @@ const System = {
             throw new Error(`No world found!`);
         }
         let serializer = new STSerializer(this);
-        let serialString = serializer.serialize(this.partsById['world'], false);
+        let serialString = serializer.serialize(this.partsById['world'], true);
 
         // If there is not a script tag in the
         // body for the serialization, create it


### PR DESCRIPTION
Our serialization isn't coming out in a pretty print format. Was this on purpose? If it's accidental, then this should change it back to the old way...

This takes care of this issue: https://github.com/UnitedLexCorp/SimpleTalk/issues/214